### PR TITLE
Update setup step of getting log-data

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,7 @@ slacklog_pages: slacklog_data $(wildcard scripts/**) $(wildcard slacklog_templat
 	touch -c slacklog_pages
 
 slacklog_data:
-	git fetch origin log-data
-	git archive origin/log-data | tar x
+	curl -Ls https://github.com/vim-jp/slacklog/archive/log-data.tar.gz | tar xz --strip-components=1 --exclude=.github
 
 .phony: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -46,8 +46,7 @@ vim-jp Slack への参加方法はこちらをどうぞ。<br>
 ログを展開
 
 ```console
-git fetch origin log-data
-git archive origin/log-data | tar x
+curl -Ls https://github.com/vim-jp/slacklog/archive/log-data.tar.gz | tar xz --strip-components=1 --exclude=.github
 ```
 
 Jekyll に必要な HTML を生成

--- a/scripts/docker.sh
+++ b/scripts/docker.sh
@@ -11,7 +11,7 @@ if which make > /dev/null 2>&1; then
   make
 else
   if [[ ! -d slacklog_data ]]; then
-    git archive origin/log-data | tar x
+    curl -Ls https://github.com/vim-jp/slacklog/archive/log-data.tar.gz | tar xz --strip-components=1 --exclude=.github
   fi
   ./scripts/generate_html.sh
 fi


### PR DESCRIPTION
`log-data` ブランチが別リポジトリになったため、取得方法を変更する。