### PR TITLE
exclude `slacklog_data/` and `tmp/` from jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,8 @@ exclude:
   - 'vendor'
   - 'slacklog_template'
   - 'Makefile'
+  - 'slacklog_data'
+  - 'tmp'
 
 # デフォルトと同じだが「utf-8で記事を書こう」という宣言的な意味合で残した。
 encoding: utf-8


### PR DESCRIPTION
slacklog_data は 変換元のソースだから jekyll の対象ではないはずです。
tmp/ は .gitignore に記載されてる適当なファイル置き場なのでやはり jekyll の対象ではありません。

なので両方とも jekyll の `exclude` に追加しました。

for #24