### PR TITLE
unite template notifications to `{{ ... }}` 

### DIFF
--- a/scripts/lib/generator.go
+++ b/scripts/lib/generator.go
@@ -94,7 +94,12 @@ func (g *HTMLGenerator) generateIndex(path string, channels []Channel) error {
 	params["channels"] = channels
 	tmplPath := filepath.Join(g.templateDir, "index.tmpl")
 	name := filepath.Base(tmplPath)
-	t, err := template.New(name).Delims("<<", ">>").ParseFiles(tmplPath)
+	t, err := template.New(name).
+		Funcs(map[string]interface{}{
+			"jekyll_through": jekyllThrough,
+			"J":              jekyllThrough, // shorthand for "jekyll_through"
+		}).
+		ParseFiles(tmplPath)
 	if err != nil {
 		return err
 	}
@@ -158,7 +163,12 @@ func (g *HTMLGenerator) generateChannelIndex(channel Channel, keys []MessageMont
 
 	tempPath := filepath.Join(g.templateDir, "channel_index.tmpl")
 	name := filepath.Base(tempPath)
-	t, err := template.New(name).Delims("<<", ">>").ParseFiles(tempPath)
+	t, err := template.New(name).
+		Funcs(map[string]interface{}{
+			"jekyll_through": jekyllThrough,
+			"J":              jekyllThrough, // shorthand for "jekyll_through"
+		}).
+		ParseFiles(tempPath)
 	if err != nil {
 		return err
 	}
@@ -183,7 +193,6 @@ func (g *HTMLGenerator) generateMessageDir(channel Channel, key MessageMonthKey,
 	tmplPath := filepath.Join(g.templateDir, "channel_per_month_index.tmpl")
 	name := filepath.Base(tmplPath)
 	t, err := template.New(name).
-		Delims("<<", ">>").
 		Funcs(map[string]interface{}{
 			"visible": g.isVisibleMessage,
 			"datetime": func(ts string) string {
@@ -251,6 +260,8 @@ func (g *HTMLGenerator) generateMessageDir(channel Channel, key MessageMonthKey,
 			"hasNextMonth": func(key MessageMonthKey) bool {
 				return g.s.HasNextMonth(channel.ID, key)
 			},
+			"jekyll_through": jekyllThrough,
+			"J":              jekyllThrough, // shorthand for "jekyll_through"
 		}).ParseFiles(tmplPath)
 	if err != nil {
 		return err
@@ -290,4 +301,8 @@ func executeAndWrite(tmpl *template.Template, data interface{}, filename string)
 		return err
 	}
 	return nil
+}
+
+func jekyllThrough(s string) string {
+	return "{{ " + s + " }}"
 }

--- a/slacklog_template/channel_index.tmpl
+++ b/slacklog_template/channel_index.tmpl
@@ -1,19 +1,19 @@
 ---
 # vim:set ts=2 sts=2 sw=2 et:
 layout: slacklog
-title: vim-jp.slack.com log - &#35<< .channel.Name >>
-permalink: /<< .channel.ID >>/index:output_ext
+title: vim-jp.slack.com log - &#35{{ .channel.Name }}
+permalink: /{{ .channel.ID }}/index:output_ext
 ---
 <div>
-<h2><a href='{{ site.baseurl }}/'>vim-jp.slack.com log</a> - &#35<< .channel.Name >></h2>
+<h2><a href='{{ jekyll_through "site.baseurl" }}/'>vim-jp.slack.com log</a> - &#35{{ .channel.Name }}</h2>
 
 <p>参加方法、各チャンネルの概要等は以下を参照して下さい。<br>
 <a href='/docs/chat.html'>vim-jpのチャットルームについて</a></p>
 
 <ul>
-<<- range .keys >>
-<li><a href='{{ site.baseurl }}/<< $.channel.ID >>/<< .Year >>/<< .Month >>/index.html'><< .Year >>年<< .Month >>月</a></li>
-<<- end >>
+{{- range .keys }}
+<li><a href='{{ jekyll_through "site.baseurl" }}/{{ $.channel.ID }}/{{ .Year }}/{{ .Month }}/index.html'>{{ .Year }}年{{ .Month }}月</a></li>
+{{- end }}
 </ul>
 
 </div>

--- a/slacklog_template/channel_per_month_index.tmpl
+++ b/slacklog_template/channel_per_month_index.tmpl
@@ -1,195 +1,195 @@
 ---
 # vim:set ts=2 sts=2 sw=2 et:
 layout: slacklog
-title: vim-jp.slack.com log - &#35<< .channel.Name >> - << .monthKey.Year >>年<< .monthKey.Month >>月
-permalink: /<< .channel.ID >>/<< .monthKey.Year >>/<< .monthKey.Month >>/index:output_ext
+title: vim-jp.slack.com log - &#35{{ .channel.Name }} - {{ .monthKey.Year }}年{{ .monthKey.Month }}月
+permalink: /{{ .channel.ID }}/{{ .monthKey.Year }}/{{ .monthKey.Month }}/index:output_ext
 ---
 <div>
 
-<<- if or (hasPrevMonth .monthKey) (hasNextMonth .monthKey) >>
+{{- if or (hasPrevMonth .monthKey) (hasNextMonth .monthKey) }}
 <header class='slacklog-header'>
-  <<- if hasPrevMonth .monthKey >>
-  <a class='slacklog-prev-month' href='{{ site.baseurl }}/<< .channel.ID >>/<< .monthKey.PrevYear >>/<< .monthKey.PrevMonth >>/'>&lt;&lt;&nbsp;<< .monthKey.PrevYear >>年<< .monthKey.PrevMonth >>月</a>
-  <<- end >>
-  <<- if hasNextMonth .monthKey >>
-  <a class='slacklog-next-month' href='{{ site.baseurl }}/<< .channel.ID >>/<< .monthKey.NextYear >>/<< .monthKey.NextMonth >>/'><< .monthKey.NextYear >>年<< .monthKey.NextMonth >>月&nbsp;&gt;&gt;</a>
-  <<- end >>
+  {{- if hasPrevMonth .monthKey }}
+  <a class='slacklog-prev-month' href='{{ jekyll_through "site.baseurl" }}/{{ .channel.ID }}/{{ .monthKey.PrevYear }}/{{ .monthKey.PrevMonth }}/'>&lt;&lt;&nbsp;{{ .monthKey.PrevYear }}年{{ .monthKey.PrevMonth }}月</a>
+  {{- end }}
+  {{- if hasNextMonth .monthKey }}
+  <a class='slacklog-next-month' href='{{ jekyll_through "site.baseurl" }}/{{ .channel.ID }}/{{ .monthKey.NextYear }}/{{ .monthKey.NextMonth }}/'>{{ .monthKey.NextYear }}年{{ .monthKey.NextMonth }}月&nbsp;&gt;&gt;</a>
+  {{- end }}
 </header>
-<<- end >>
+{{- end }}
 
-<h2><a href='{{ site.baseurl }}/'>vim-jp.slack.com log</a> - <a href='{{ site.baseurl }}/<< .channel.ID >>/'>&#35<< .channel.Name >></a> - << .monthKey.Year >>年<< .monthKey.Month >>月</h2>
+<h2><a href='{{ jekyll_through "site.baseurl" }}/'>vim-jp.slack.com log</a> - <a href='{{ jekyll_through "site.baseurl" }}/{{ .channel.ID }}/'>&#35{{ .channel.Name }}</a> - {{ .monthKey.Year }}年{{ .monthKey.Month }}月</h2>
 
-<<- range .msgs >>
-<<- if visible . >>
-  <span class='slacklog-message' id='ts-<< .Ts >>'>
-    <<- if .Trail >>
-    <img class='slacklog-icon slacklog-trail' src='<< userIconUrl . >>'>
-    <span class='slacklog-name slacklog-trail'><< username . >></span>
-    <a class='slacklog-datetime slacklog-trail' href='#ts-<< .Ts >>'><< datetime .Ts >></a>
-    <a class='slacklog-slack-link' href='https://vim-jp.slack.com/archives/<< $.channel.ID >>/p<< slackPermalink .Ts >>'>Slack</a>
-    <<- else >>
-    <img class='slacklog-icon' src='<< userIconUrl . >>'>
-    <span class='slacklog-name'><< username . >></span>
-    <a class='slacklog-datetime' href='#ts-<< .Ts >>'><< datetime .Ts >></a>
-    <a class='slacklog-slack-link' href='https://vim-jp.slack.com/archives/<< $.channel.ID >>/p<< slackPermalink .Ts >>'>Slack</a>
-    <<- end >>
+{{- range .msgs }}
+{{- if visible . }}
+  <span class='slacklog-message' id='ts-{{ .Ts }}'>
+    {{- if .Trail }}
+    <img class='slacklog-icon slacklog-trail' src='{{ userIconUrl . }}'>
+    <span class='slacklog-name slacklog-trail'>{{ username . }}</span>
+    <a class='slacklog-datetime slacklog-trail' href='#ts-{{ .Ts }}'>{{ datetime .Ts }}</a>
+    <a class='slacklog-slack-link' href='https://vim-jp.slack.com/archives/{{ $.channel.ID }}/p{{ slackPermalink .Ts }}'>Slack</a>
+    {{- else }}
+    <img class='slacklog-icon' src='{{ userIconUrl . }}'>
+    <span class='slacklog-name'>{{ username . }}</span>
+    <a class='slacklog-datetime' href='#ts-{{ .Ts }}'>{{ datetime .Ts }}</a>
+    <a class='slacklog-slack-link' href='https://vim-jp.slack.com/archives/{{ $.channel.ID }}/p{{ slackPermalink .Ts }}'>Slack</a>
+    {{- end }}
 
-    <<- if and (ne .ThreadTs "") (ne .ThreadTs .Ts) >>
+    {{- if and (ne .ThreadTs "") (ne .ThreadTs .Ts) }}
     <span class='slacklog-thread-broadcast-link'>
-      このスレッドに返信しました : <a href='#ts-<<- .ThreadTs >>'><<- threadRootText .ThreadTs >></a>
+      このスレッドに返信しました : <a href='#ts-{{- .ThreadTs }}'>{{- threadRootText .ThreadTs }}</a>
     </span>
-    <<- end >>
+    {{- end }}
 
-    <span class='slacklog-text'><< text . >></span>
+    <span class='slacklog-text'>{{ text . }}</span>
 
-    <<- if .Attachments >>
+    {{- if .Attachments }}
     <span class='slacklog-attachments'>
-      <<- range .Attachments >>
-      <<- if eq .ServiceName "GitHub" >>
+      {{- range .Attachments }}
+      {{- if eq .ServiceName "GitHub" }}
         <span class='slacklog-attachment slacklog-attachment-github'>
-          <span class='slacklog-attachment-github-serviceicon'><img src='<< .ServiceIcon >>'></span>
-          <span class='slacklog-attachment-github-servicename'><< html .ServiceName >></span>
-          <span class='slacklog-attachment-github-title'><a href='<< .TitleLink >>'><< html .Title >></a></span>
-          <span class='slacklog-attachment-github-text'><< attachmentText . >></span>
+          <span class='slacklog-attachment-github-serviceicon'><img src='{{ .ServiceIcon }}'></span>
+          <span class='slacklog-attachment-github-servicename'>{{ html .ServiceName }}</span>
+          <span class='slacklog-attachment-github-title'><a href='{{ .TitleLink }}'>{{ html .Title }}</a></span>
+          <span class='slacklog-attachment-github-text'>{{ attachmentText . }}</span>
         </span>
-      <<- else if eq .ServiceName "twitter" >>
+      {{- else if eq .ServiceName "twitter" }}
         <span class='slacklog-attachment slacklog-attachment-twitter'>
-          <span class='slacklog-attachment-twitter-authoricon'><img src='<< .AuthorIcon >>'></span>
-          <span class='slacklog-attachment-twitter-authorname'><< .AuthorName >></span>
-          <span class='slacklog-attachment-twitter-authorsubname'><< .AuthorSubname >></span>
-          <span class='slacklog-attachment-twitter-text'><< attachmentText . >></span>
-          <span class='slacklog-attachment-twitter-footericon'><img src='<< .FooterIcon >>'></span>
-          <span class='slacklog-attachment-twitter-footer'><< html .Footer >></span>
-          <<- if .VideoHTML >>
-          <span class='slacklog-attachment-twitter-video'><< .VideoHTML >></span>
-          <<- end >>
+          <span class='slacklog-attachment-twitter-authoricon'><img src='{{ .AuthorIcon }}'></span>
+          <span class='slacklog-attachment-twitter-authorname'>{{ .AuthorName }}</span>
+          <span class='slacklog-attachment-twitter-authorsubname'>{{ .AuthorSubname }}</span>
+          <span class='slacklog-attachment-twitter-text'>{{ attachmentText . }}</span>
+          <span class='slacklog-attachment-twitter-footericon'><img src='{{ .FooterIcon }}'></span>
+          <span class='slacklog-attachment-twitter-footer'>{{ html .Footer }}</span>
+          {{- if .VideoHTML }}
+          <span class='slacklog-attachment-twitter-video'>{{ .VideoHTML }}</span>
+          {{- end }}
         </span>
-      <<- else if or .Title .Text >>
+      {{- else if or .Title .Text }}
         <span class='slacklog-attachment slacklog-attachment-other'>
-          <<- if and .ServiceIcon .ServiceName >>
+          {{- if and .ServiceIcon .ServiceName }}
           <div>
-            <span class='slacklog-attachment-other-serviceicon'><img src='<< .ServiceIcon >>'></span>
-            <span class='slacklog-attachment-other-servicename'><< html .ServiceName >></span>
+            <span class='slacklog-attachment-other-serviceicon'><img src='{{ .ServiceIcon }}'></span>
+            <span class='slacklog-attachment-other-servicename'>{{ html .ServiceName }}</span>
           </div>
-          <<- end >>
-          <<- if and .Title .TitleLink >>
-          <div class='slacklog-attachment-other-title'><a href='<< .TitleLink >>'><< html .Title >></a></div>
-          <<- else if .Title >>
-          <div class='slacklog-attachment-other-title'><< html .Title >></div>
-          <<- end >>
-          <<- if .Text >>
-          <div class='slacklog-attachment-other-text'><< attachmentText . >></div>
-          <<- end >>
-          <<- if .ThumbURL >>
-          <div class='slacklog-attachment-other-thumb'><img src='<< .ThumbURL >>' width='<< .ThumbWidth >>' height='<< .ThumbHeight >>' alt='<< html .Title >>'></div>
-          <<- end >>
+          {{- end }}
+          {{- if and .Title .TitleLink }}
+          <div class='slacklog-attachment-other-title'><a href='{{ .TitleLink }}'>{{ html .Title }}</a></div>
+          {{- else if .Title }}
+          <div class='slacklog-attachment-other-title'>{{ html .Title }}</div>
+          {{- end }}
+          {{- if .Text }}
+          <div class='slacklog-attachment-other-text'>{{ attachmentText . }}</div>
+          {{- end }}
+          {{- if .ThumbURL }}
+          <div class='slacklog-attachment-other-thumb'><img src='{{ .ThumbURL }}' width='{{ .ThumbWidth }}' height='{{ .ThumbHeight }}' alt='{{ html .Title }}'></div>
+          {{- end }}
         </span>
-      <<- end >>
-      <<- end >>
+      {{- end }}
+      {{- end }}
     </span>
-    <<- end >>
+    {{- end }}
 
-    <<- if .Files >>
+    {{- if .Files }}
     <span class='slacklog-files'>
-      <<- range .Files >>
+      {{- range .Files }}
       <div>
-        <a href="{{ site.baseurl }}/files/<< .OriginalFilePath >>">
-        <<- if eq .TopLevelMimetype "image" >>
-        <img src="{{ site.baseurl }}/files/<< .ThumbImagePath >>" width="<< .ThumbImageWidth >>" height="<< .ThumbImageHeight >>" alt="<< .Title >>">
-        <<- else if eq .TopLevelMimetype "video" >>
-        <video src="{{ site.baseurl }}/files/<< .OriginalFilePath >>" poster="{{ site.baseurl }}/files/<< .ThumbVideoPath >>" controls>>" alt="<< .Title >>">
+        <a href="{{ jekyll_through "site.baseurl" }}/files/{{ .OriginalFilePath }}">
+        {{- if eq .TopLevelMimetype "image" }}
+        <img src="{{ jekyll_through "site.baseurl" }}/files/{{ .ThumbImagePath }}" width="{{ .ThumbImageWidth }}" height="{{ .ThumbImageHeight }}" alt="{{ .Title }}">
+        {{- else if eq .TopLevelMimetype "video" }}
+        <video src="{{ jekyll_through "site.baseurl" }}/files/{{ .OriginalFilePath }}" poster="{{ jekyll_through "site.baseurl" }}/files/{{ .ThumbVideoPath }}" controls>>" alt="{{ .Title }}">
         </video>
-        <<- else >>
-        [[ダウンロード: << .Title >>(<< .PrettyType >>)]]
-        <<- end >>
+        {{- else }}
+        [[ダウンロード: {{ .Title }}({{ .PrettyType }})]]
+        {{- end }}
         </a>
       </div>
-      <<- end >>
+      {{- end }}
     </span>
-    <<- end >>
+    {{- end }}
 
-    <<- if threads .Ts >>
+    {{- if threads .Ts }}
     <details class='slacklog-thread'>
       <summary class-'slacklog-thread-summary'>
-        <<- threadNum .ThreadTs >> 件の返信
-        <span class='slacklog-thread-mtime'>最終返信: <<- threadMtime .ThreadTs >></span>
+        {{- threadNum .ThreadTs }} 件の返信
+        <span class='slacklog-thread-mtime'>最終返信: {{- threadMtime .ThreadTs }}</span>
       </summary>
-      <<- range threads .Ts >>
-      <<- if eq .Subtype "thread_broadcast" >>
+      {{- range threads .Ts }}
+      {{- if eq .Subtype "thread_broadcast" }}
       <span class='slacklog-message-broadcasted'>
         <span class='slacklog-thread-broadcast-text'>チャンネルにも投稿済</span>
-        <span class='slacklog-message' id='ts-<< .Ts >>'>
-      <<- else >>
-      <span class='slacklog-message' id='ts-<< .Ts >>'>
-      <<- end >>
-        <img class='slacklog-icon' src='<< userIconUrl . >>'>
-        <span class='slacklog-name'><< username . >></span>
-        <a class='slacklog-datetime' href='#ts-<< .Ts >>'><< datetime .Ts >></a>
-        <span class='slacklog-text'><< text . >></span>
+        <span class='slacklog-message' id='ts-{{ .Ts }}'>
+      {{- else }}
+      <span class='slacklog-message' id='ts-{{ .Ts }}'>
+      {{- end }}
+        <img class='slacklog-icon' src='{{ userIconUrl . }}'>
+        <span class='slacklog-name'>{{ username . }}</span>
+        <a class='slacklog-datetime' href='#ts-{{ .Ts }}'>{{ datetime .Ts }}</a>
+        <span class='slacklog-text'>{{ text . }}</span>
 
-        <<- if .Attachments >>
+        {{- if .Attachments }}
         <span class='slacklog-attachments'>
-          <<- range .Attachments >>
-          <<- if eq .ServiceName "GitHub" >>
+          {{- range .Attachments }}
+          {{- if eq .ServiceName "GitHub" }}
             <span class='slacklog-attachment slacklog-attachment-github'>
-              <span class='slacklog-attachment-github-serviceicon'><img src='<< .ServiceIcon >>'></span>
-              <span class='slacklog-attachment-github-servicename'><< html .ServiceName >></span>
-              <span class='slacklog-attachment-github-title'><a href='<< .TitleLink >>'><< html .Title >></a></span>
-              <span class='slacklog-attachment-github-text'><< attachmentText . >></span>
+              <span class='slacklog-attachment-github-serviceicon'><img src='{{ .ServiceIcon }}'></span>
+              <span class='slacklog-attachment-github-servicename'>{{ html .ServiceName }}</span>
+              <span class='slacklog-attachment-github-title'><a href='{{ .TitleLink }}'>{{ html .Title }}</a></span>
+              <span class='slacklog-attachment-github-text'>{{ attachmentText . }}</span>
             </span>
-          <<- else if eq .ServiceName "twitter" >>
+          {{- else if eq .ServiceName "twitter" }}
             <span class='slacklog-attachment slacklog-attachment-twitter'>
-              <span class='slacklog-attachment-twitter-authoricon'><img src='<< .AuthorIcon >>'></span>
-              <span class='slacklog-attachment-twitter-authorname'><< .AuthorName >></span>
-              <span class='slacklog-attachment-twitter-authorsubname'><< .AuthorSubname >></span>
-              <span class='slacklog-attachment-twitter-text'><< attachmentText . >></span>
-              <span class='slacklog-attachment-twitter-footericon'><img src='<< .FooterIcon >>'></span>
-              <span class='slacklog-attachment-twitter-footer'><< html .Footer >></span>
-              <<- if .VideoHTML >>
-              <span class='slacklog-attachment-twitter-video'><< .VideoHTML >></span>
-              <<- end >>
+              <span class='slacklog-attachment-twitter-authoricon'><img src='{{ .AuthorIcon }}'></span>
+              <span class='slacklog-attachment-twitter-authorname'>{{ .AuthorName }}</span>
+              <span class='slacklog-attachment-twitter-authorsubname'>{{ .AuthorSubname }}</span>
+              <span class='slacklog-attachment-twitter-text'>{{ attachmentText . }}</span>
+              <span class='slacklog-attachment-twitter-footericon'><img src='{{ .FooterIcon }}'></span>
+              <span class='slacklog-attachment-twitter-footer'>{{ html .Footer }}</span>
+              {{- if .VideoHTML }}
+              <span class='slacklog-attachment-twitter-video'>{{ .VideoHTML }}</span>
+              {{- end }}
             </span>
-          <<- else if or .Title .Text >>
+          {{- else if or .Title .Text }}
             <span class='slacklog-attachment slacklog-attachment-other'>
-              <<- if and .ServiceIcon .ServiceName >>
+              {{- if and .ServiceIcon .ServiceName }}
               <div>
-                <span class='slacklog-attachment-other-serviceicon'><img src='<< .ServiceIcon >>'></span>
-                <span class='slacklog-attachment-other-servicename'><< html .ServiceName >></span>
+                <span class='slacklog-attachment-other-serviceicon'><img src='{{ .ServiceIcon }}'></span>
+                <span class='slacklog-attachment-other-servicename'>{{ html .ServiceName }}</span>
               </div>
-              <<- end >>
-              <<- if and .Title .TitleLink >>
-              <div class='slacklog-attachment-other-title'><a href='<< .TitleLink >>'><< html .Title >></a></div>
-              <<- else if .Title >>
-              <div class='slacklog-attachment-other-title'><< html .Title >></div>
-              <<- end >>
-              <<- if .Text >>
-              <div class='slacklog-attachment-other-text'><< attachmentText . >></div>
-              <<- end >>
+              {{- end }}
+              {{- if and .Title .TitleLink }}
+              <div class='slacklog-attachment-other-title'><a href='{{ .TitleLink }}'>{{ html .Title }}</a></div>
+              {{- else if .Title }}
+              <div class='slacklog-attachment-other-title'>{{ html .Title }}</div>
+              {{- end }}
+              {{- if .Text }}
+              <div class='slacklog-attachment-other-text'>{{ attachmentText . }}</div>
+              {{- end }}
             </span>
-          <<- end >>
-          <<- end >>
+          {{- end }}
+          {{- end }}
         </span>
-        <<- end >>
+        {{- end }}
       </span>
-      <<- if eq .Subtype "thread_broadcast" >>
+      {{- if eq .Subtype "thread_broadcast" }}
       </span>
-      <<- end >>
-      <<- end >>
+      {{- end }}
+      {{- end }}
     </details>
-    <<- end >>
+    {{- end }}
   </span>
-<<- end >>
-<<- end >>
+{{- end }}
+{{- end }}
 
-<<- if or (hasPrevMonth .monthKey) (hasNextMonth .monthKey) >>
+{{- if or (hasPrevMonth .monthKey) (hasNextMonth .monthKey) }}
 <footer class='slacklog-footer'>
-  <<- if hasPrevMonth .monthKey >>
-  <a class='slacklog-prev-month' href='{{ site.baseurl }}/<< .channel.ID >>/<< .monthKey.PrevYear >>/<< .monthKey.PrevMonth >>/'>&lt;&lt;&nbsp;<< .monthKey.PrevYear >>年<< .monthKey.PrevMonth >>月</a>
-  <<- end >>
-  <<- if hasNextMonth .monthKey >>
-  <a class='slacklog-next-month' href='{{ site.baseurl }}/<< .channel.ID >>/<< .monthKey.NextYear >>/<< .monthKey.NextMonth >>/'><< .monthKey.NextYear >>年<< .monthKey.NextMonth >>月&nbsp;&gt;&gt;</a>
-  <<- end >>
+  {{- if hasPrevMonth .monthKey }}
+  <a class='slacklog-prev-month' href='{{ jekyll_through "site.baseurl" }}/{{ .channel.ID }}/{{ .monthKey.PrevYear }}/{{ .monthKey.PrevMonth }}/'>&lt;&lt;&nbsp;{{ .monthKey.PrevYear }}年{{ .monthKey.PrevMonth }}月</a>
+  {{- end }}
+  {{- if hasNextMonth .monthKey }}
+  <a class='slacklog-next-month' href='{{ jekyll_through "site.baseurl" }}/{{ .channel.ID }}/{{ .monthKey.NextYear }}/{{ .monthKey.NextMonth }}/'>{{ .monthKey.NextYear }}年{{ .monthKey.NextMonth }}月&nbsp;&gt;&gt;</a>
+  {{- end }}
 </footer>
-<<- end >>
+{{- end }}
 
 </div>

--- a/slacklog_template/index.tmpl
+++ b/slacklog_template/index.tmpl
@@ -5,15 +5,15 @@ title: vim-jp.slack.com log
 permalink: /index:output_ext
 ---
 <div>
-<h2><a href='{{ post.url }}'>{{ page.title }}</a></h2>
+<h2><a href='{{ jekyll_through "post.url" }}'>{{ jekyll_through "page.title" }}</a></h2>
 
 <p>参加方法、各チャンネルの概要等は以下を参照して下さい。<br>
 <a href='/docs/chat.html'>vim-jpのチャットルームについて</a></p>
 
 <ul>
-<<- range .channels >>
-<li><a href='{{ site.baseurl }}/<< .ID >>/'>#<< .Name >></a></li>
-<<- end >>
+{{- range .channels }}
+<li><a href='{{ jekyll_through "site.baseurl" }}/{{ .ID }}/'>#{{ .Name }}</a></li>
+{{- end }}
 </ul>
 
 </div>


### PR DESCRIPTION
こうするとテンプレートの表記方法を統一できそう

表記を統一できると syntax が適用できるようになって
フロント側の負荷が軽減するはず。