### PR TITLE
html のビルドを slacklog-generator 側の Actions で行う

### DIFF
--- a/.github/workflows/build_pages.yml
+++ b/.github/workflows/build_pages.yml
@@ -11,10 +11,24 @@ jobs:
     steps:
       - uses: 'actions/checkout@v2'
         with:
+          path: 'generator'
+      - uses: 'actions/checkout@v2'
+        with:
           repository: 'vim-jp/slacklog'
-          ref: 'master'
+          path: 'data'
+          ref: 'log-data'
           ssh-key: '${{ secrets.SLACKLOG_SSH_KEY }}'
       - name: 'Trigger'
         run: |
-          git tag rebuild
-          git push origin rebuild
+          cd generator/scripts
+          go run ./main.go generate-html ./config.json ../slacklog_template/ ../../data/slacklog_data/ ../../data/slacklog_pages/
+          cd ..
+          cp -r _config.yml _layouts assets favicon.ico sitemap.xml ../data
+          cd ../data
+          rm -fr slacklog_data/ .github/
+          git checkout --orphan=gh-pages --quiet
+          git add --all --force
+          git config user.email "slacklog@vim-jp.org"
+          git config user.name "Slack Log Generator"
+          git commit --message='publish' --quiet
+          git push --force origin gh-pages


### PR DESCRIPTION
今までは以下のようになっていた。

1. `slacklog-generator` の `master` ブランチが更新
2. GitHub Actions が走り、`slacklog` 側に `rebuild` タグを push
3. タグの push を契機に `slacklog` 側で GitHub Actions が走り、新しい `gh-pages` を push

しかしこれは回りくどいので、ビルドして新しい gh-pages を push するところまで `slacklog-generator` 側で行う。