### PR TITLE
Fix the field name of EmojiTable

### DIFF
--- a/scripts/lib/emoji.go
+++ b/scripts/lib/emoji.go
@@ -5,16 +5,18 @@ import (
 )
 
 // EmojiTable : 絵文字データを保持する。
-// urlMapは絵文字名をキーとし、画像が置いてあるURLが値である。
+// ExtMapは絵文字名をキーとし、画像の拡張子が値である。
+// 絵文字は事前に全てダウンロードしている、という前提であり、そのため拡張子のみ
+// を保持している。
 type EmojiTable struct {
-	URLMap map[string]string
+	ExtMap map[string]string
 }
 
 // NewEmojiTable : pathに指定したJSON形式の絵文字データを読み込み、EmojiTableを
 // 生成する。
 func NewEmojiTable(path string) (*EmojiTable, error) {
 	emojis := &EmojiTable{
-		URLMap: map[string]string{},
+		ExtMap: map[string]string{},
 	}
 
 	if info, err := os.Stat(path); err != nil || info.IsDir() {
@@ -23,7 +25,7 @@ func NewEmojiTable(path string) (*EmojiTable, error) {
 		return nil, os.ErrNotExist
 	}
 
-	if err := ReadFileAsJSON(path, &emojis.URLMap); err != nil {
+	if err := ReadFileAsJSON(path, &emojis.ExtMap); err != nil {
 		return nil, err
 	}
 

--- a/scripts/lib/store.go
+++ b/scripts/lib/store.go
@@ -111,7 +111,7 @@ func (s *LogStore) GetDisplayNameMap() map[string]string {
 }
 
 func (s *LogStore) GetEmojiMap() map[string]string {
-	return s.et.URLMap
+	return s.et.ExtMap
 }
 
 func (s *LogStore) GetThread(channelID, ts string) (*Thread, bool) {


### PR DESCRIPTION
`EmojiTable` のフィールド名が実態に合っていなかったので `URLMap` から `ExtMap` に修正