### PR TITLE
change resolution of time of messages in thread

### DIFF
--- a/scripts/lib/generator.go
+++ b/scripts/lib/generator.go
@@ -198,6 +198,9 @@ func (g *HTMLGenerator) generateMessageDir(channel Channel, key MessageMonthKey,
 			"datetime": func(ts string) string {
 				return TsToDateTime(ts).Format("2日 15:04:05")
 			},
+			"threadMessageTime": func(msgTs, threadTs string) string {
+				return LevelOfDetailTime(TsToDateTime(msgTs), TsToDateTime(threadTs))
+			},
 			"slackPermalink": func(ts string) string {
 				return strings.Replace(ts, ".", "", 1)
 			},
@@ -226,7 +229,7 @@ func (g *HTMLGenerator) generateMessageDir(channel Channel, key MessageMonthKey,
 			"attachmentText": g.generateAttachmentText,
 			"threadMtime": func(ts string) string {
 				if t, ok := g.s.GetThread(channel.ID, ts); ok {
-					return t.LastReplyTime().Format("2日 15:04:05")
+					return LevelOfDetailTime(t.LastReplyTime(), TsToDateTime(ts))
 				}
 				return ""
 			},

--- a/scripts/lib/time.go
+++ b/scripts/lib/time.go
@@ -31,3 +31,19 @@ func TsToDateTime(ts string) time.Time {
 	}
 	return time.Unix(sec, nsec).In(japan)
 }
+
+// LevelOfDetailTime returns a label string which represents time.  The
+// resolution of the string is determined by differece from base time in 4
+// levels.
+func LevelOfDetailTime(target, base time.Time) string {
+	if target.Year() != base.Year() {
+		return target.Format("2006年1月2日 15:04:05")
+	}
+	if target.Month() != base.Month() {
+		return target.Format("1月2日 15:04:05")
+	}
+	if target.Day() != base.Day() {
+		return target.Format("2日 15:04:05")
+	}
+	return target.Format("15:04:05")
+}

--- a/slacklog_template/channel_per_month_index.tmpl
+++ b/slacklog_template/channel_per_month_index.tmpl
@@ -124,7 +124,7 @@ permalink: /{{ .channel.ID }}/{{ .monthKey.Year }}/{{ .monthKey.Month }}/index:o
       {{- end }}
         <img class='slacklog-icon' src='{{ userIconUrl . }}'>
         <span class='slacklog-name'>{{ username . }}</span>
-        <a class='slacklog-datetime' href='#ts-{{ .Ts }}'>{{ datetime .Ts }}</a>
+        <a class='slacklog-datetime' href='#ts-{{ .Ts }}'>{{ threadMessageTime .Ts .ThreadTs }}</a>
         <span class='slacklog-text'>{{ text . }}</span>
 
         {{- if .Attachments }}


### PR DESCRIPTION
for https://github.com/vim-jp/slacklog-generator/issues/28

thread 内の時刻が `2日 15:04:05` の表記のため
月を跨ぐほどの遅い返信だと違和感が強いのを修正した。

具体的にはスレッド自身の時刻 (`.ThreadTs`) とスレッド内メッセージの時刻 (`.Ts`) の差から
以下の4つのケースに分けて異なるフォーマットを使用した。

1. 年が違う - `2006年1月2日 15:04:05`
2. 月が違う - `1月2日 15:04:05`
3. 日が違う - `2日 15:04:05`
4. 年月日が同じ - `15:04:05`

合わせて「最終返信」の表記もこのフォーマットに修正した。

この結果以下のような表示になる。
(なおこのデータはもともと当日のレスポンスだったものに、同月10日後の返信と、月を跨いだ返信を無理矢理加えたものから生成した)

![image](https://user-images.githubusercontent.com/468368/81073831-2b38ee00-8f23-11ea-9578-f504405d9323.png)

