### PR TITLE
generate diffs on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  biuld-tool:
+  build-tool:
     name: 'Build and Compile the Tool'
     runs-on: 'ubuntu-latest'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,6 @@ name: CI
 
 on: [push, pull_request]
 
-env:
-  GOPATH: ${{ github.workspace }}/..
-
 jobs:
 
   gotool:
@@ -25,3 +22,31 @@ jobs:
 
     - name: Test
       run: cd scripts && go test ./...
+
+  diff:
+    name: 'Compare Generated Pages'
+    runs-on: 'ubuntu-latest'
+
+    steps:
+    - name: 'Check out target branch (commit)'
+      uses: 'actions/checkout@v2'
+      with:
+        # FIXME: 全部取るのはやりすぎ。必要最小限(mereg-base origin/master
+        # HEAD)までだけ取れたら良いのだが…
+        fetch-depth: 0
+
+    - name: 'Preparations'
+      run: |
+        # origin/master の ref が比較のために要る
+        git fetch origin master
+
+        # log-data の取得と展開
+        curl -Ls https://github.com/vim-jp/slacklog/archive/log-data.tar.gz | tar xz --strip-components=1 --exclude=.github
+
+        # 出力用のディレクトリ
+        mkdir -p tmp
+
+    - name: 'Compare pages'
+      run: |
+        mkdir -p tmp
+        ./scripts/pages_diff.sh | tee tmp/pages.diff | head -n 1000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: cd scripts && go test ./...
 
   diff:
-    name: 'Compare Generated Pages'
+    name: 'Compare Pages and Site'
     runs-on: 'ubuntu-latest'
 
     steps:
@@ -46,10 +46,19 @@ jobs:
         # log-data の取得と展開
         curl -Ls https://github.com/vim-jp/slacklog/archive/log-data.tar.gz | tar xz --strip-components=1 --exclude=.github
 
-        # 出力用のディレクトリ
+        # 出力用のディレクトリ。docker から書くのに a+wx が必要だった
         mkdir -p tmp
+        chmod a+wx tmp
+
+        # jekyll on docker をセットアップするのに必要
+        touch Gemfile.lock
+        chmod a+w Gemfile.lock
 
     - name: 'Compare pages'
       run: |
-        mkdir -p tmp
-        ./scripts/pages_diff.sh | tee tmp/pages.diff | head -n 1000
+        ./scripts/pages_diff.sh
+
+    - name: 'Compare site'
+      run: |
+        umask 000
+        ./scripts/site_diff.sh -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,14 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+    branches:
+    - '**'
 
 jobs:
 
-  gotool:
-    name: 'scripts/main.go'
+  biuld-tool:
+    name: 'Build and Compile the Tool'
     runs-on: 'ubuntu-latest'
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,32 @@ jobs:
 
     - name: 'Compare pages'
       run: |
-        ./scripts/pages_diff.sh
+        ./scripts/pages_diff.sh -o tmp/pages.diff
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: diffs-${{ github.run_id }}
+        path: tmp/pages.diff
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: log-pages-diff-${{ github.run_id }}
+        path: tmp/pages_diff/*.log
 
     - name: 'Compare site'
       run: |
         umask 000
-        ./scripts/site_diff.sh -d
+        # FIXME: 中で実行している docker run jekyll/jekyll:pages が Gems を全部
+        # ダウンロードしてるっぽい。actions/cache などでキャッシュできたら少し
+        # は速くなりそう。
+        ./scripts/site_diff.sh -d -o tmp/site.diff
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: diffs-${{ github.run_id }}
+        path: tmp/site.diff
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: log-site-diff-${{ github.run_id }}
+        path: tmp/site_diff/*.log

--- a/README.md
+++ b/README.md
@@ -178,6 +178,26 @@ log-data ブランチにはSlackからエクスポートしたデータを格納
 
 4. 更新内容を log-data ブランチに `commit --amend` して `push -f`
 
+## Pull Request の影響の確認の方法
+
+以下の手順で Pull Request への `pages_diff.sh` と `site_diff.sh` の実行結果を
+Artifacts として Web から取得できます。レビューの際に利用してください。
+
+1. Pull Request の <b>Checks</b> タブを開く
+2. <b>CI</b> ワークフロー(右側)を選択
+3. <b>Compare Pages and Site</b> ジョブ(右側)を選択
+4. <b>Artifacts</b> ドロワー(左側)を選択
+5. `diffs-{数値}` アーティファクトをダウンロード
+
+以下のスクリーンショットは、上記の選択個所をマーキングしたものです。
+
+![](https://raw.githubusercontent.com/wiki/vim-jp/slacklog-generator/images/where-are-artifacts.png)
+
+Artifacts はそれぞれ zip としてダウンロードできます。
+`diffs-*.zip` には `pages_diff.sh` と `site_diff.sh` の両方の差分が含まれています。
+`log-*.zip` はそれぞれの動作ログが含まれていますが、こちらはCIの動作デバッグ目的のものです。
+末尾の数値は [`${{ github.run_id }}`](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context) 由来です。
+
 ## LICNESE
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />この 作品 は <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">クリエイティブ・コモンズ 表示 4.0 国際 ライセンス</a>の下に提供されています。

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ $ ./scripts/site_diff.sh -f
 $ ./scripts/site_diff.sh -c
 ```
 
+差分だけを特定のファイルに出力するには `-o {filename}` オプションを使ってくださ
+い。リダイレクト (` > filename`) では差分以外の動作ログも含まれる場合がありま
+す。
+
 注意事項: `./scripts/site_diff.sh` は未コミットな変更を stash を用いて保存・復
 帰しているため staged な変更が unstaged に巻き戻ることに留意してください。
 
@@ -151,6 +155,10 @@ $ ./scripts/pages_diff.sh -f
 ```console
 $ ./scripts/pages_diff.sh -c
 ```
+
+差分だけを特定のファイルに出力するには `-o {filename}` オプションを使ってくださ
+い。リダイレクト (` > filename`) では差分以外の動作ログも含まれる場合がありま
+す。
 
 注意事項: `./scripts/pages_diff.sh` は未コミットな変更を stash を用いて保存・復
 帰しているため staged な変更が unstaged に巻き戻ることに留意してください。

--- a/README.md
+++ b/README.md
@@ -198,6 +198,19 @@ Artifacts はそれぞれ zip としてダウンロードできます。
 `log-*.zip` はそれぞれの動作ログが含まれていますが、こちらはCIの動作デバッグ目的のものです。
 末尾の数値は [`${{ github.run_id }}`](https://help.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#github-context) 由来です。
 
+### Artifacts に差分を出力している理由
+
+Artifacts に差分を出力している主な理由は2つあります。1つ目は、小さな変更でも差
+分をオンライン上のどこかに出力しないと、レビューの負荷が高すぎてそれを解消した
+かったという動機です。
+
+2つ目は、テストデータとして実際のログを使っているため、差分とはいえログの一部の
+コピーが消せない状態で永続化されるのを避けたい、という動機です。vim-jp slackで
+は参加者の「忘れられる権利」を尊重しています。
+
+以上の理由から消せる状態でデータ=差分をオンライン上にホストできる GitHub
+Actions の Artifacts を利用しています。
+
 ## LICNESE
 
 <a rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="クリエイティブ・コモンズ・ライセンス" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a><br />この 作品 は <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">クリエイティブ・コモンズ 表示 4.0 国際 ライセンス</a>の下に提供されています。

--- a/scripts/pages_diff.sh
+++ b/scripts/pages_diff.sh
@@ -26,7 +26,7 @@ generate_html() {
   rm -rf $outdir
   echo "generate_html to: $outdir" 1>&2
   mkdir -p $outdir
-  go build -o ${cmd} ./main.go
+  go build -o ${cmd} ./main.go 1>&2
   ${cmd} generate-html ./config.json ../slacklog_template/ ../slacklog_data/ ${outdir} > ${outdir}.generate-html.log 2>&1
   rm -f ${cmd}
 }
@@ -60,7 +60,7 @@ if [ $force -ne 0 -o ! \( -d $base_pages \) ] ; then
 
   # merge-base に巻き戻し generate-html を実行する
   git reset -q --hard ${base_commit}
-  echo "move to base: $(git rev-parse HEAD)" 2>&1
+  echo "move to base: $(git rev-parse HEAD)" 1>&2
   generate_html ${base_pages}
 
   # 退避したHEADと変更を復帰する
@@ -69,8 +69,9 @@ if [ $force -ne 0 -o ! \( -d $base_pages \) ] ; then
     git stash pop -q
   fi
 
-  echo "return to current: $(git rev-parse HEAD)" 2>&1
+  echo "return to current: $(git rev-parse HEAD)" 1>&2
 fi
 
 # 差分を出力
-diff -uNr ${base_pages} ${current_pages}
+echo "" 1>&2
+diff -uNr ${base_pages} ${current_pages} || true

--- a/scripts/site_diff.sh
+++ b/scripts/site_diff.sh
@@ -6,13 +6,15 @@ force=0
 clean=0
 update=0
 docker=0
+outdiff=""
 
-while getopts fcud OPT ; do
+while getopts fcudo: OPT ; do
   case $OPT in
     f) force=1 ;;
     c) clean=1 ;;
     u) update=1 ;;
     d) docker=1 ;;
+    o) outdiff="$OPTARG" ;;
   esac
 done
 
@@ -86,5 +88,9 @@ if [ $force -ne 0 -o ! \( -d $base_pages \) ] ; then
 fi
 
 # 差分を出力
-echo "" 1>&2
-diff -uNr -x sitemap.xml ${base_pages} ${current_pages} || true
+if [ x"$outdiff" = x ] ; then
+  echo "" 1>&2
+  diff -uNr -x sitemap.xml ${base_pages} ${current_pages} || true
+else
+  diff -uNr -x sitemap.xml ${base_pages} ${current_pages} > "$outdiff" || true
+fi

--- a/scripts/site_diff.sh
+++ b/scripts/site_diff.sh
@@ -24,7 +24,7 @@ cmd=${outrootdir}/slacklog-tools
 
 build_tool() {
   cd scripts
-  go build -o ../${cmd} ./main.go
+  go build -o ../${cmd} ./main.go 1>&2
   cd ..
 }
 
@@ -39,7 +39,7 @@ generate_site() {
   rm -f ${cmd}
   rm -rf ${outdir}
   if [ $docker -ne 0 ] ; then
-    docker run --rm -it --volume="$PWD:/srv/jekyll" jekyll/jekyll:pages jekyll build -d ${outdir} > ${outdir}.docker-jekyll-build.log 2>&1
+    docker run --rm -t --volume="$PWD:/srv/jekyll" jekyll/jekyll:pages jekyll build -d ${outdir} > ${outdir}.docker-jekyll-build.log 2>&1
   else
     jekyll build -d ${outdir} > ${outdir}.jekyll-build.log 2>&1
   fi
@@ -73,7 +73,7 @@ if [ $force -ne 0 -o ! \( -d $base_pages \) ] ; then
 
   # merge-base に巻き戻し generate-html を実行する
   git reset -q --hard ${base_commit}
-  echo "move to base: $(git rev-parse HEAD)" 2>&1
+  echo "move to base: $(git rev-parse HEAD)" 1>&2
   generate_site ${base_commit}
 
   # 退避したHEADと変更を復帰する
@@ -82,8 +82,9 @@ if [ $force -ne 0 -o ! \( -d $base_pages \) ] ; then
     git stash pop -q
   fi
 
-  echo "return to current: $(git rev-parse HEAD)" 2>&1
+  echo "return to current: $(git rev-parse HEAD)" 1>&2
 fi
 
 # 差分を出力
-diff -uNr -x sitemap.xml ${base_pages} ${current_pages}
+echo "" 1>&2
+diff -uNr -x sitemap.xml ${base_pages} ${current_pages} || true


### PR DESCRIPTION
fix #11 

Actions で pages\_diff.sh と site\_diff.sh を走らせてその結果(差分)をArtifactsにアップするようにしました。

上の Checks タブから確認してみてください。

1. Pull Request の <b>Checks</b> タブを開く
2. <b>CI</b> ワークフロー(右側)を選択
3. <b>Compare Pages and Site</b> ジョブ(右側)を選択
4. <b>Artifacts</b> ドロワー(左側)を選択
5. `diffs-{数値}` アーティファクトをダウンロード