### PR TITLE
treat message by pointer

### DIFF
--- a/scripts/lib/generator.go
+++ b/scripts/lib/generator.go
@@ -122,14 +122,9 @@ func (g *HTMLGenerator) generateChannelDir(path string, channel Channel) (bool, 
 		return false, fmt.Errorf("could not create %s directory: %w", path, err)
 	}
 
-	keys := make([]MessageMonthKey, 0, len(msgsMap))
-	for key := range msgsMap {
-		keys = append(keys, key)
-	}
-
 	if err := g.generateChannelIndex(
 		channel,
-		keys,
+		msgsMap.Keys(),
 		filepath.Join(path, "index.html"),
 	); err != nil {
 		return true, err
@@ -178,7 +173,7 @@ func (g *HTMLGenerator) generateChannelIndex(channel Channel, keys []MessageMont
 	return nil
 }
 
-func (g *HTMLGenerator) generateMessageDir(channel Channel, key MessageMonthKey, msgs []Message, path string) error {
+func (g *HTMLGenerator) generateMessageDir(channel Channel, key MessageMonthKey, msgs Messages, path string) error {
 	if err := os.MkdirAll(path, 0777); err != nil {
 		return fmt.Errorf("could not create %s directory: %w", path, err)
 	}
@@ -233,7 +228,7 @@ func (g *HTMLGenerator) generateMessageDir(channel Channel, key MessageMonthKey,
 				}
 				return ""
 			},
-			"threads": func(ts string) []Message {
+			"threads": func(ts string) Messages {
 				if t, ok := g.s.GetThread(channel.ID, ts); ok {
 					return t.Replies()
 				}

--- a/scripts/lib/store.go
+++ b/scripts/lib/store.go
@@ -73,7 +73,7 @@ func (s *LogStore) HasPrevMonth(channelID string, key MessageMonthKey) bool {
 	return false
 }
 
-func (s *LogStore) GetMessagesPerMonth(channelID string) (map[MessageMonthKey][]Message, error) {
+func (s *LogStore) GetMessagesPerMonth(channelID string) (MessagesMap, error) {
 	mt, ok := s.mts[channelID]
 	if !ok {
 		return nil, fmt.Errorf("not found channel: id=%s", channelID)

--- a/scripts/lib/thread.go
+++ b/scripts/lib/thread.go
@@ -9,21 +9,30 @@ import (
 // repliesにはそのスレッドへの返信メッセージが入る。先頭メッセージは含まない。
 type Thread struct {
 	rootMsg *Message
-	replies []Message
+	replies Messages
 }
 
-func (t Thread) LastReplyTime() time.Time {
-	return TsToDateTime(t.replies[len(t.replies)-1].Ts)
+func (th Thread) LastReplyTime() time.Time {
+	return TsToDateTime(th.replies[len(th.replies)-1].Ts)
 }
 
-func (t Thread) ReplyCount() int {
-	return len(t.replies)
+func (th Thread) ReplyCount() int {
+	return len(th.replies)
 }
 
-func (t Thread) RootText() string {
-	return t.rootMsg.Text
+func (th Thread) RootText() string {
+	return th.rootMsg.Text
 }
 
-func (t Thread) Replies() []Message {
-	return t.replies
+func (th Thread) Replies() Messages {
+	return th.replies
+}
+
+// Put puts a message to the thread as "root" or "reply".
+func (th *Thread) Put(m *Message) {
+	if m.IsRootOfThread() {
+		th.rootMsg = m
+	} else {
+		th.replies = append(th.replies, m)
+	}
 }


### PR DESCRIPTION
`Message` をポインタで取り扱うようにしました。これは #36 で指摘・依頼されたようにツール側で `Message` 以下の情報を埋める場合に値のままだと非効率&バグの温床になるのを事前に防ぎます。
(例: メッセージ側には情報が入ってるがスレッドには入ってないなどなど)

その結果として以下のことが起こっています。

* `Messages` (`[]*Message`)  の定義
    * `Sort()` メソッドを生やした & 使ってる場所の見通しが良くなった
* `MessagesMap` (`map[MessageMonthKey]Messages`) の定義
    * `Keys()` メソッドを生やした & 使ってる場所の見通しが良くなった
* `Thread` 関連
    * `Put()` を生やした & 使ってる場所の見通しが良くなった
    * レシーバの名前を `t` から `th` へ変更した。 `t` のままテストを書き始めるとめんどいことになるので
* いくつかのループからインデックスが消え、インデックスを使った参照が消え見通しが良くなった