### PR TITLE
Don't use jekyll's baseurl at generator

### DIFF
--- a/.github/workflows/build_pages.yml
+++ b/.github/workflows/build_pages.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'Trigger'
         run: |
           cd generator/scripts
-          go run ./main.go generate-html ./config.json ../slacklog_template/ ../../data/slacklog_data/ ../../data/slacklog_pages/
+          BASEURL=/slacklog go run ./main.go generate-html ./config.json ../slacklog_template/ ../../data/slacklog_data/ ../../data/slacklog_pages/
           cd ..
           cp -r _config.yml _layouts assets favicon.ico sitemap.xml ../data
           cd ../data

--- a/scripts/lib/generator.go
+++ b/scripts/lib/generator.go
@@ -12,6 +12,8 @@ import (
 	"text/template"
 )
 
+var baseURL = os.Getenv("BASEURL")
+
 // HTMLGenerator : ログデータからHTMLを生成するための構造体。
 type HTMLGenerator struct {
 	// text/template形式のテンプレートが置いてあるディレクトリ
@@ -91,6 +93,7 @@ func (g *HTMLGenerator) Generate(outDir string) error {
 func (g *HTMLGenerator) generateIndex(path string, channels []Channel) error {
 	params := make(map[string]interface{})
 	SortChannel(channels)
+	params["baseURL"] = baseURL
 	params["channels"] = channels
 	tmplPath := filepath.Join(g.templateDir, "index.tmpl")
 	name := filepath.Base(tmplPath)
@@ -153,6 +156,7 @@ func (g *HTMLGenerator) generateChannelIndex(channel Channel, keys []MessageMont
 	})
 
 	params := make(map[string]interface{})
+	params["baseURL"] = baseURL
 	params["channel"] = channel
 	params["keys"] = keys
 
@@ -179,6 +183,7 @@ func (g *HTMLGenerator) generateMessageDir(channel Channel, key MessageMonthKey,
 	}
 
 	params := make(map[string]interface{})
+	params["baseURL"] = baseURL
 	params["channel"] = channel
 	params["monthKey"] = key
 	params["msgs"] = msgs

--- a/slacklog_template/channel_index.tmpl
+++ b/slacklog_template/channel_index.tmpl
@@ -8,7 +8,7 @@ permalink: /{{ .channel.ID }}/index:output_ext
   <h4 class="text-gray pb-2 border-bottom">&#35{{ $.channel.Name }}</h4>
   <nav class="SideNav bg-white">
     {{- range .keys }}
-      <a class="SideNav-item" href="{{ J "site.baseurl" }}/{{ $.channel.ID }}/{{ .Year }}/{{ .Month }}/index.html">{{ .Year }}年{{ .Month }}月</a>
+      <a class="SideNav-item" href="{{ $.baseURL }}/{{ $.channel.ID }}/{{ .Year }}/{{ .Month }}/index.html">{{ .Year }}年{{ .Month }}月</a>
     {{- end }}
   </nav>
 </div>

--- a/slacklog_template/channel_per_month_index.tmpl
+++ b/slacklog_template/channel_per_month_index.tmpl
@@ -7,7 +7,7 @@ permalink: /{{ .channel.ID }}/{{ .monthKey.Year }}/{{ .monthKey.Month }}/index:o
 <div class="m-3">
   <nav aria-label="Breadcrumb">
     <ol>
-      <li class="breadcrumb-item f4"><a href="{{ J "site.baseurl" }}/{{ .channel.ID }}/">&#35{{ .channel.Name }}</a></li>
+      <li class="breadcrumb-item f4"><a href="{{ $.baseURL }}/{{ .channel.ID }}/">&#35{{ .channel.Name }}</a></li>
       <li class="breadcrumb-item f4" aria-current="page">{{ .monthKey.Year }}年{{ .monthKey.Month }}月</li>
     </ol>
   </nav>
@@ -127,11 +127,11 @@ permalink: /{{ .channel.ID }}/{{ .monthKey.Year }}/{{ .monthKey.Month }}/index:o
       <div class="mt-2 border p-3">
         {{- range .Files }}
         <div>
-          <a href="{{ J "site.baseurl" }}/files/{{ .OriginalFilePath }}">
+          <a href="{{ $.baseURL }}/files/{{ .OriginalFilePath }}">
           {{- if eq .TopLevelMimetype "image" }}
-          <img src="{{ J "site.baseurl" }}/files/{{ .ThumbImagePath }}" width="{{ .ThumbImageWidth }}" height="{{ .ThumbImageHeight }}" alt="{{ .Title }}" />
+          <img src="{{ $.baseURL }}/files/{{ .ThumbImagePath }}" width="{{ .ThumbImageWidth }}" height="{{ .ThumbImageHeight }}" alt="{{ .Title }}" />
           {{- else if eq .TopLevelMimetype "video" }}
-          <video src="{{ J "site.baseurl" }}/files/{{ .OriginalFilePath }}" poster="{{ J "site.baseurl" }}/files/{{ .ThumbVideoPath }}" controls alt="{{ .Title }}">
+          <video src="{{ $.baseURL }}/files/{{ .OriginalFilePath }}" poster="{{ $.baseURL }}/files/{{ .ThumbVideoPath }}" controls alt="{{ .Title }}">
           </video>
           {{- else }}
           <span class="f5">[[ダウンロード: {{ .Title }}({{ .PrettyType }})]]</span>

--- a/slacklog_template/index.tmpl
+++ b/slacklog_template/index.tmpl
@@ -15,7 +15,7 @@ permalink: /index:output_ext
       </svg>
     </span>
     <span class="Toast-content">
-      参加方法、各チャンネルの概要等は<a href="{{ J "site.baseurl" }}/docs/chat.html">こちら</a>を参照して下さい。
+      参加方法、各チャンネルの概要等は<a href="{{ $.baseURL }}/docs/chat.html">こちら</a>を参照して下さい。
     </span>
   </div>
 </div>
@@ -24,7 +24,7 @@ permalink: /index:output_ext
   <h4 class="text-gray mb-2 pb-2">Channels</h4>
   <nav class="SideNav bg-white">
     {{- range .channels }}
-      <a class="SideNav-item border-top" href="{{ J "site.baseurl" }}/{{ .ID }}/">&#35{{ .Name }}</a>
+      <a class="SideNav-item border-top" href="{{ $.baseURL }}/{{ .ID }}/">&#35{{ .Name }}</a>
     {{- end }}
   </nav>
 </div>


### PR DESCRIPTION
GoでHTMLを生成している部分からjekyllの`site.baseurl`を取り除きました。
baseurl部分はgenerateコマンドを呼ぶ時に環境変数`BASEURL`で渡す形にしています

- `converter.go`の方は取り除いていません
  - ~~現状テストデータが手元になく、どのような仕様なのかが分からないため~~
    - 僕の勘違いでしたが、直すの難しそうなので一旦保留でお願いします
- テスト環境でトップレベルへの遷移がバグってたので、何も指定していない時のbaseurlを`/`にしていますが、問題があれば戻します
