### PR TITLE
Extra works for Downloader

### DIFF
--- a/scripts/lib/downloader_test.go
+++ b/scripts/lib/downloader_test.go
@@ -88,6 +88,7 @@ func TestDownloader_usingToken(t *testing.T) {
 	}
 	var got map[string]string
 	err = json.NewDecoder(f).Decode(&got)
+	f.Close()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/scripts/lib/main_test.go
+++ b/scripts/lib/main_test.go
@@ -21,7 +21,7 @@ func cleanupTmpDir(t *testing.T, path string) {
 func createTmpDir(t *testing.T) string {
 	t.Helper()
 
-	path, err := ioutil.TempDir("testdata", "slacklog")
+	path, err := ioutil.TempDir("", "slacklog")
 	if err != nil {
 		t.Fatalf("failed to createTmpDir: %s", err)
 	}

--- a/scripts/lib/message.go
+++ b/scripts/lib/message.go
@@ -63,7 +63,8 @@ func NewMessageTable() *MessageTable {
 // ReadLogDir : pathに指定したディレクトリに存在するJSON形式のメッセージデータ
 // を読み込む。
 // すでにそのディレクトリが読み込み済みの場合は処理をスキップする。
-// readAllMessagesがfalseである場合は特定のサブタイプを持つメッセージのみをmsgMapに登録する。
+// デフォルトでは特定のサブタイプを持つメッセージのみをmsgMapに登録するが、
+// readAllMessages が true である場合はすべてのメッセージを登録する。
 func (m *MessageTable) ReadLogDir(path string, readAllMessages bool) error {
 	dir, err := os.Open(path)
 	if err != nil {


### PR DESCRIPTION
#22 での残件に対応しました。やったことは以下の3つです。

* 大きくなり得る&先頭以外使ってない `errs []errors` の代わりに `firstError error` にした
* テストの安定化
    * システムが提供するテンポラリディレクトリを使うように
    * Windowsでも実行できるように (開いたままのファイルを clean up してた)
* readAllMessages についてのコメントを修正: 先に一般的な説明をしてから特殊なケースの説明をするように