### PR TITLE
Fix type of MessageAttachment.Ts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-cmp v0.4.0
 	github.com/joho/godotenv v1.3.0
 	github.com/kyokomi/emoji v2.2.2+incompatible
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/gorilla/websocket v1.2.0 h1:VJtLvh6VQym50czpZzx07z/kw9EgAxI3x1ZB8taTMQQ=
 github.com/gorilla/websocket v1.2.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -16,4 +18,5 @@ github.com/slack-go/slack v0.6.4 h1:cxOqFgM5RW6mdEyDqAJutFk3qiORK9oHRKi5bPqkY9o=
 github.com/slack-go/slack v0.6.4/go.mod h1:sGRjv3w+ERAUMMMbldHObQPBcNSyVB7KLKYfnwUFBfw=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
-github.com/vim-jp/slacklog v0.0.0-20200505062424-3da495236d48 h1:mFwuNBGw2LoQAVm+Ucyj7/vFWQggEA5jtCQ0BBDJGsg=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/slacklog/message.go
+++ b/internal/slacklog/message.go
@@ -513,7 +513,7 @@ type MessageAttachment struct {
 	FooterIcon      string   `json:"footer_icon,omitempty"`
 	IsMsgUnfurl     bool     `json:"is_msg_unfurl,omitempty"`
 	MrkdwnIn        []string `json:"mrkdwn_in,omitempty"`
-	Ts              *Ts      `json:"ts,omitempty"`
+	Ts              Ts      `json:"ts,omitempty"`
 }
 
 type MessageReaction struct {

--- a/internal/slacklog/message.go
+++ b/internal/slacklog/message.go
@@ -513,7 +513,7 @@ type MessageAttachment struct {
 	FooterIcon      string   `json:"footer_icon,omitempty"`
 	IsMsgUnfurl     bool     `json:"is_msg_unfurl,omitempty"`
 	MrkdwnIn        []string `json:"mrkdwn_in,omitempty"`
-	Ts              string   `json:"ts,omitempty"`
+	Ts              *Ts      `json:"ts,omitempty"`
 }
 
 type MessageReaction struct {

--- a/internal/slacklog/message.go
+++ b/internal/slacklog/message.go
@@ -513,7 +513,7 @@ type MessageAttachment struct {
 	FooterIcon      string   `json:"footer_icon,omitempty"`
 	IsMsgUnfurl     bool     `json:"is_msg_unfurl,omitempty"`
 	MrkdwnIn        []string `json:"mrkdwn_in,omitempty"`
-	Ts              Ts      `json:"ts,omitempty"`
+	Ts              *Ts      `json:"ts,omitempty"`
 }
 
 type MessageReaction struct {

--- a/internal/slacklog/message_test.go
+++ b/internal/slacklog/message_test.go
@@ -14,12 +14,13 @@ func TestMessageAttachment_Ts_JSON(t *testing.T) {
 	}{
 		{`{"id":0,"ts":"1234.5678"}`, MessageAttachment{
 			ID: 0,
-			Ts: Ts{false, "1234.5678"},
+			Ts: &Ts{false, "1234.5678"},
 		}},
 		{`{"id":0,"ts":1234.5678}`, MessageAttachment{
 			ID: 0,
-			Ts: Ts{true, "1234.5678"},
+			Ts: &Ts{true, "1234.5678"},
 		}},
+		{`{"id":0}`, MessageAttachment{ID: 0, Ts: nil}},
 	} {
 		var act1 MessageAttachment
 		err := json.Unmarshal([]byte(tc.json), &act1)

--- a/internal/slacklog/message_test.go
+++ b/internal/slacklog/message_test.go
@@ -1,0 +1,42 @@
+package slacklog
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMessageAttachment_Ts_JSON(t *testing.T) {
+	for _, tc := range []struct {
+		json string
+		ma   MessageAttachment
+	}{
+		{`{"id":0,"ts":"1234.5678"}`, MessageAttachment{
+			ID: 0,
+			Ts: Ts{false, "1234.5678"},
+		}},
+		{`{"id":0,"ts":1234.5678}`, MessageAttachment{
+			ID: 0,
+			Ts: Ts{true, "1234.5678"},
+		}},
+	} {
+		var act1 MessageAttachment
+		err := json.Unmarshal([]byte(tc.json), &act1)
+		if err != nil {
+			t.Fatalf("unmarshal(%q) failed: %s", tc.json, err)
+		}
+		if diff := cmp.Diff(tc.ma, act1); diff != "" {
+			t.Fatalf("unexpected unmarshal MessageAttachment: -want +got\n%s", diff)
+		}
+
+		b, err := json.Marshal(tc.ma)
+		if err != nil {
+			t.Fatalf("marshal(%+v) failed: %s", tc.ma, err)
+		}
+		act2 := string(b)
+		if diff := cmp.Diff(tc.json, act2); diff != "" {
+			t.Fatalf("unexpected marshal Ts: -want +got\n%s", diff)
+		}
+	}
+}

--- a/internal/slacklog/ts.go
+++ b/internal/slacklog/ts.go
@@ -1,0 +1,45 @@
+package slacklog
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+)
+
+type Ts struct {
+	IsNumber bool
+	Value    string
+}
+
+var _ json.Marshaler = (*Ts)(nil)
+var _ json.Unmarshaler = (*Ts)(nil)
+
+func (ts *Ts) UnmarshalJSON(b []byte) error {
+	var v interface{}
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return nil
+	}
+	switch w := v.(type) {
+	case string:
+		ts.IsNumber = false
+		ts.Value = w
+	case float64:
+		ts.IsNumber = true
+		ts.Value = strconv.FormatFloat(w, 'g', -1, 64)
+	default:
+		return fmt.Errorf("unsupproted type for Ts: %t", v)
+	}
+	return nil
+}
+
+func (ts *Ts) MarshalJSON() ([]byte, error) {
+	if ts.IsNumber {
+		f, err := strconv.ParseFloat(ts.Value, 64)
+		if err != nil {
+			f = 0
+		}
+		return json.Marshal(f)
+	}
+	return json.Marshal(ts.Value)
+}

--- a/internal/slacklog/ts.go
+++ b/internal/slacklog/ts.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 )
 
+// Ts is a type represents "Ts" fields in message.go or so.
 type Ts struct {
 	IsNumber bool
 	Value    string
@@ -14,6 +15,7 @@ type Ts struct {
 var _ json.Marshaler = (*Ts)(nil)
 var _ json.Unmarshaler = (*Ts)(nil)
 
+// UnmarshalJSON implements "encoding/json".Unmarshaller interface.
 func (ts *Ts) UnmarshalJSON(b []byte) error {
 	var v interface{}
 	err := json.Unmarshal(b, &v)
@@ -33,7 +35,8 @@ func (ts *Ts) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func (ts *Ts) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements "encoding/json".Marshaller interface.
+func (ts Ts) MarshalJSON() ([]byte, error) {
 	if ts.IsNumber {
 		f, err := strconv.ParseFloat(ts.Value, 64)
 		if err != nil {

--- a/internal/slacklog/ts_test.go
+++ b/internal/slacklog/ts_test.go
@@ -1,0 +1,47 @@
+package slacklog
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestTs_Unmarshal(t *testing.T) {
+	for _, tc := range []struct {
+		json string
+		exp  Ts
+	}{
+		{`"1234.5678"`, Ts{false, "1234.5678"}},
+		{`1234.5678`, Ts{true, "1234.5678"}},
+	} {
+		var act Ts
+		err := json.Unmarshal([]byte(tc.json), &act)
+		if err != nil {
+			t.Fatalf("unmarshal(%q) failed: %s", tc.json, err)
+		}
+		if diff := cmp.Diff(tc.exp, act); diff != "" {
+			t.Fatalf("unexpected unmarshal Ts: -want +got\n%s", diff)
+		}
+	}
+}
+
+func TestTs_Marshal(t *testing.T) {
+	for _, tc := range []struct {
+		ts  Ts
+		exp string
+	}{
+		{Ts{false, "1234.5678"}, `"1234.5678"`},
+		{Ts{true, "1234.5678"}, `1234.5678`},
+	} {
+		var act string
+		b, err := json.Marshal(tc.ts)
+		if err != nil {
+			t.Fatalf("marshal(%+v) failed: %s", tc.ts, err)
+		}
+		act = string(b)
+		if diff := cmp.Diff(tc.exp, act); diff != "" {
+			t.Fatalf("unexpected marshal Ts: -want +got\n%s", diff)
+		}
+	}
+}


### PR DESCRIPTION
【悲報】attachment の `"ts"` は数値の場合がある…。