### PR TITLE
Remove workaround for jekyll

### DIFF
--- a/internal/slacklog/message.go
+++ b/internal/slacklog/message.go
@@ -443,14 +443,7 @@ func (f *MessageFile) DownloadFilename(url, suffix string) string {
 		}
 	}
 
-	filename := filenameReplacer.Replace(name + suffix + ext)
-
-	// XXX: Jekyll doesn't publish files that name starts with some characters
-	if strings.HasPrefix(filename, "_") || strings.HasPrefix(filename, ".") {
-		filename = "files" + filename
-	}
-
-	return filename
+	return filenameReplacer.Replace(name + suffix + ext)
 }
 
 type MessageIcons struct {


### PR DESCRIPTION
Jekyll たんが publish してくれないのでしかたなく名前を変えていた一部の files のファイル名を変えないようにします。

既存の `slacklog` リポジトリの `log-data` ブランチ内のファイルの更新が必要になります。ビルドとかは問題ないけど、直すまではリンク切れが発生します (ほんのごく一部のファイルです)。