### PR TITLE
build.sh: Hard linking if installed rsync

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,6 +2,16 @@
 
 set -eu
 
+copy() {
+  if which rsync > /dev/null && [[ -d $1 ]] ; then
+    local dir
+    dir=$(realpath $1)
+    rsync -avP --link-dest=$dir/ $dir/ $2/$1
+  else
+    cp -a $1 $2
+  fi
+}
+
 outdir="_site"
 
 while getopts o: OPT ; do
@@ -12,7 +22,7 @@ done
 
 mkdir -p ${outdir}
 
-cp -a assets ${outdir}
-cp -a emojis ${outdir}
-cp -p favicon.ico ${outdir}
-cp -a files ${outdir}
+copy assets ${outdir}
+copy emojis ${outdir}
+copy favicon.ico ${outdir}
+copy files ${outdir}


### PR DESCRIPTION
rsyncが存在する場合はハードリンクを貼るようにしました
Fix #73