### PR TITLE
Quarantine logdata

### DIFF
--- a/.github/workflows/build_pages.yml
+++ b/.github/workflows/build_pages.yml
@@ -2,30 +2,45 @@ name: 'Trigger Rebuild Pages'
 on:
   push:
     branches:
-      - master
+      - '**'
 
 jobs:
   build-pages:
-    name: 'Trigger Rebuild Pages'
+    name: 'Generate htdocs and Update https://vim-jp.org/slacklog/'
     runs-on: 'ubuntu-latest'
+
     steps:
       - uses: 'actions/checkout@v2'
         with:
           path: 'generator'
+
       - uses: 'actions/checkout@v2'
         with:
           repository: 'vim-jp/slacklog'
           path: 'data'
           ref: 'log-data'
           ssh-key: '${{ secrets.SLACKLOG_SSH_KEY }}'
-      - name: 'Trigger'
+
+      - name: 'Generate htdocs'
         run: |
           cd generator
           BASEURL=/slacklog go run . generate-html scripts/config.json templates/ ../data/slacklog_data/ ../data/
           cp -r assets ../data
+          rm -fr ../data/slacklog_data/ ../data/.github/
+          touch ../data/.nojekyll
+          # create finger print
           cd ../data
-          rm -fr slacklog_data/ .github/
-          touch .nojekyll
+          find . -type d -name '.git' -prune -o -type f -print0 | xargs -0 md5sum > ../files.txt
+
+      - name: 'Save fingerprint'
+        uses: actions/upload-artifact@v2
+        with:
+          name: fingerprint
+          path: files.txt
+
+      - name: 'Update https://vim-jp.org/slacklog/'
+        if: github.ref == 'master'
+        run: |
           git checkout --orphan=gh-pages --quiet
           git add --all --force
           git config user.email "slacklog@vim-jp.org"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: go test . ./internal/... ./subcmd/...
 
   diff:
-    name: 'Compare Pages and Site'
+    name: 'Compare Site'
     runs-on: 'ubuntu-latest'
 
     steps:
@@ -44,7 +44,7 @@ jobs:
         git fetch origin master
 
         # log-data の取得と展開
-        curl -Ls https://github.com/vim-jp/slacklog/archive/log-data.tar.gz | tar xz --strip-components=1 --exclude=.github
+        make logdata
 
         # 出力用のディレクトリ
         mkdir -p tmp

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,7 @@
 *.swp
 /_site/
 /tmp/
-/slacklog_data/
-/files/
-/emojis/
 .env
 slacklog-generator
 *.exe
+/_logdata/

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,38 @@ lint:
 slacklog_data:
 	curl -Ls https://github.com/vim-jp/slacklog/archive/log-data.tar.gz | tar xz --strip-components=1 --exclude=.github
 
-.phony: clean
+.PHONY: clean
 clean:
 	rm -rf _site
-	rm -rf emojis
-	rm -rf files
-	rm -rf slacklog_data
-	rm -rf slacklog_pages
+
+.PHONY: distclean
+distclean: clean logdata-clean
+
+##############################################################################
+# manage logdata
+
+.PHONY: logdata
+logdata: _logdata
+
+.PHONY: logdata-clean
+logdata-clean:
+	rm -rf logdata
+
+.PHONY: logdata-distclean
+logdata-distclean: logdata-clean
+	rm -f tmp/log-data.tar.gz
+
+.PHONY: logdata-restore
+logdata-restore: logdata-clean logdata
+
+.PHONY: logdata-update
+logdata-update: logdata-distclean logdata
+
+_logdata: tmp/log-data.tar.gz
+	rm -rf $@
+	mkdir -p $@
+	tar xz --strip-components=1 --exclude=.github -f tmp/log-data.tar.gz -C $@
+
+tmp/log-data.tar.gz:
+	mkdir -p tmp
+	curl -Lo $@ https://github.com/vim-jp/slacklog/archive/log-data.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ clean: go-clean
 distclean: clean logdata-distclean
 
 ##############################################################################
-## Go
+# Go
 
 .PHONY: build
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,20 @@
-_site: slacklog_data $(wildcard scripts/**) $(wildcard templates/**)
+.PHONY: generate
+generate: _site
+
+_site: _logdata $(wildcard scripts/**) $(wildcard templates/**)
 	./scripts/generate_html.sh
 	./scripts/build.sh
 	touch -c _site
+
+.PHONY: clean
+clean: go-clean
+	rm -rf _site
+
+.PHONY: distclean
+distclean: clean logdata-distclean
+
+##############################################################################
+## Go
 
 .PHONY: build
 build:
@@ -19,15 +32,9 @@ vet:
 lint:
 	golint . ./internal/... ./subcmd/...
 
-slacklog_data:
-	curl -Ls https://github.com/vim-jp/slacklog/archive/log-data.tar.gz | tar xz --strip-components=1 --exclude=.github
-
-.PHONY: clean
-clean:
-	rm -rf _site
-
-.PHONY: distclean
-distclean: clean logdata-clean
+.PHONY: go-clean
+go-clean:
+	go clean
 
 ##############################################################################
 # manage logdata

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ vim-jp Slack への参加方法はこちらをどうぞ。<br>
 ログを展開
 
 ```console
-curl -Ls https://github.com/vim-jp/slacklog/archive/log-data.tar.gz | tar xz --strip-components=1 --exclude=.github
+$ make logdata
 ```
 
 HTMLの生成

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,9 +15,9 @@ mkdir -p ${outdir}
 cp -a assets ${outdir}
 
 for d in emojis files ; do
-  if [ -d _logdata/${d} ] ; then
-    cp -a _logdata/${d} ${outdir}
-  else
-    cp -a ${d} ${outdir}
+  if [ ! -d _logdata/${d} ] ; then
+    echo "one of input missing. please run 'make logdata' and retry"
+    exit 1
   fi
+  cp -a _logdata/${d} ${outdir}
 done

--- a/scripts/download_emoji.sh
+++ b/scripts/download_emoji.sh
@@ -4,4 +4,4 @@ set -eu
 
 cd "$(dirname "$0")/.." || exit "$?"
 
-go run . download-emoji emojis/ slacklog_data/emoji.json
+go run . download-emoji _logdata/emojis/ _logdata/slacklog_data/emoji.json

--- a/scripts/download_emoji.sh
+++ b/scripts/download_emoji.sh
@@ -4,4 +4,9 @@ set -eu
 
 cd "$(dirname "$0")/.." || exit "$?"
 
+if  [ ! -d _logdata/slacklog_data/ ] ; then
+  echo "one of input missing. please make assure _logdata/slacklog_data/ directory"
+  exit 1
+fi
+
 go run . download-emoji _logdata/emojis/ _logdata/slacklog_data/emoji.json

--- a/scripts/download_files.sh
+++ b/scripts/download_files.sh
@@ -4,4 +4,9 @@ set -eu
 
 cd "$(dirname "$0")/.." || exit "$?"
 
-go run . download-files slacklog_data/ files/
+if  [ ! -d _logdata/slacklog_data/ ] ; then
+  echo "one of input missing. please make assure _logdata/slacklog_data/ directory"
+  exit 1
+fi
+
+go run . download-files _logdata/slacklog_data/ _logdata/files/

--- a/scripts/generate_html.sh
+++ b/scripts/generate_html.sh
@@ -4,4 +4,9 @@ set -eu
 
 cd "$(dirname "$0")/.." || exit "$?"
 
-go run . generate-html scripts/config.json templates/ slacklog_data/ _site/
+if [ ! -d _logdata/slacklog_data/ ] ; then
+  echo "one of input missing. please run 'make logdata' and retry"
+  exit 1
+fi
+
+go run . generate-html scripts/config.json templates/ _logdata/slacklog_data/ _site/

--- a/scripts/site_diff.sh
+++ b/scripts/site_diff.sh
@@ -18,7 +18,7 @@ done
 
 cd "$(dirname "$0")/.." || exit "$?"
 
-outrootdir=tmp/site_diff
+outrootdir=tmp/_site_diff
 current_pages=${outrootdir}/current
 cmd=${outrootdir}/slacklog-tools
 
@@ -37,15 +37,18 @@ generate_site() {
   id=$1 ; shift
   outdir=${outrootdir}/${id}
   echo "jekyll build to: ${outdir}" 1>&2
-  rm -rf slacklog_pages
+  rm -rf ${outdir}
   build_tool
   tmpldir=slacklog_template/
   if [ -d templates ] ; then
     tmpldir=templates/
   fi
-  ${cmd} generate-html scripts/config.json ${tmpldir} slacklog_data/ slacklog_pages/ > ${outdir}.generate-html.log 2>&1
+  logdir=slacklog_data/
+  if [ -d _logdata ] ; then
+    logdir=_logdata/slacklog_data/
+  fi
+  ${cmd} generate-html scripts/config.json ${tmpldir} ${logdir} ${outdir}/ > ${outdir}.generate-html.log 2>&1
   rm -f ${cmd}
-  rm -rf ${outdir}
   ./scripts/build.sh -o $outdir > ${outdir}.build.log 2>&1
 }
 


### PR DESCRIPTION
fix #78 

ログ(slacklogレポジトリのlog-dataブランチ)の展開を
プロジェクトルートではなく `_logdata/` 下で行う PR です。
この変更を適用後に `make logdata` することでログを展開できます。

展開後の古いログ emojis/ files/ そして slacklog_data/ は手動で消してください。

また `_logdata/` 下を壊してしまった場合には `make logdata-restore` でローカルキャッシュからログを再展開します。

最新のログを取得して展開するには `make logdata-update` です。