### PR TITLE
use _logdata for emojis and files if available

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -13,6 +13,12 @@ done
 mkdir -p ${outdir}
 
 cp -a assets ${outdir}
-cp -a emojis ${outdir}
 cp -p favicon.ico ${outdir}
-cp -a files ${outdir}
+
+for d in emojis files ; do
+  if [ -d _logdata/${d} ] ; then
+    cp -a _logdata/${d} ${outdir}
+  else
+    cp -a ${d} ${outdir}
+  fi
+done


### PR DESCRIPTION
preparation for merging #78

#78 では _logdata にデータを集約させてるんですが、build.sh が対応してないため merge-base がビルドできなくなってしまうのをこの修正で対応します。