### PR TITLE
omit "index.html" from URL

### DIFF
--- a/templates/channel_index.tmpl
+++ b/templates/channel_index.tmpl
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="{{ $.baseURL }}/assets/css/site.css" type="text/css" />
 <link rel="stylesheet" href="https://unpkg.com/@primer/css/dist/primer.css" type="text/css" />
 <link rel="alternate" type="application/rss+xml" title="RSS" href="//vim-jp.org/rss.xml" />
-<link rel="canonical" href="{{ $.baseURL }}/{{ .channel.ID }}/index.html" />
+<link rel="canonical" href="{{ $.baseURL }}/{{ .channel.ID }}/" />
 <link rel="shortcut icon" type="image/x-icon" href="/assets/images/favicon.ico" />
 <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico" />
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
@@ -32,7 +32,7 @@
           <h4 class="text-gray pb-2 border-bottom">&#35{{ $.channel.Name }}</h4>
           <nav class="SideNav bg-white">
             {{- range .keys }}
-              <a class="SideNav-item" href="{{ $.baseURL }}/{{ $.channel.ID }}/{{ .Year }}/{{ .Month }}/index.html">{{ .Year }}年{{ .Month }}月</a>
+              <a class="SideNav-item" href="{{ $.baseURL }}/{{ $.channel.ID }}/{{ .Year }}/{{ .Month }}/">{{ .Year }}年{{ .Month }}月</a>
             {{- end }}
           </nav>
         </div>

--- a/templates/channel_per_month_index.tmpl
+++ b/templates/channel_per_month_index.tmpl
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="{{ $.baseURL }}/assets/css/site.css" type="text/css" />
 <link rel="stylesheet" href="https://unpkg.com/@primer/css/dist/primer.css" type="text/css" />
 <link rel="alternate" type="application/rss+xml" title="RSS" href="//vim-jp.org/rss.xml" />
-<link rel="canonical" href="{{ $.baseURL }}/{{ .channel.ID }}/{{ .monthKey.Year }}/{{ .monthKey.Month }}/index.html" />
+<link rel="canonical" href="{{ $.baseURL }}/{{ .channel.ID }}/{{ .monthKey.Year }}/{{ .monthKey.Month }}/" />
 <link rel="shortcut icon" type="image/x-icon" href="/assets/images/favicon.ico" />
 <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico" />
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>

--- a/templates/index.tmpl
+++ b/templates/index.tmpl
@@ -7,7 +7,7 @@
 <link rel="stylesheet" href="{{ $.baseURL }}/assets/css/site.css" type="text/css" />
 <link rel="stylesheet" href="https://unpkg.com/@primer/css/dist/primer.css" type="text/css" />
 <link rel="alternate" type="application/rss+xml" title="RSS" href="//vim-jp.org/rss.xml" />
-<link rel="canonical" href="{{ $.baseURL }}/index.html" />
+<link rel="canonical" href="{{ $.baseURL }}/" />
 <link rel="shortcut icon" type="image/x-icon" href="/assets/images/favicon.ico" />
 <link rel="icon" type="image/x-icon" href="/assets/images/favicon.ico" />
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>


### PR DESCRIPTION
fix #50 

各ページへのリンクから index.html を省略した。
合わせて canonical からも index.html を消した。

これで正式なURLは全部 index.html 抜きで、 `/` で終わることとなる。