### PR TITLE
fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,15 +22,15 @@ build:
 
 .PHONY: test
 test:
-	go test . ./internal/... ./subcmd/...
+	go test ./...
 
 .PHONY: vet
 vet:
-	go vet . ./internal/... ./subcmd/...
+	go vet ./...
 
 .PHONY: lint
 lint:
-	golint . ./internal/... ./subcmd/...
+	golint ./...
 
 .PHONY: go-clean
 go-clean:
@@ -44,7 +44,7 @@ logdata: _logdata
 
 .PHONY: logdata-clean
 logdata-clean:
-	rm -rf logdata
+	rm -rf _logdata
 
 .PHONY: logdata-distclean
 logdata-distclean: logdata-clean


### PR DESCRIPTION
* remove redundant path specs for `go test`, `go vet` and `golint`

    添付ファイル等が _logdata/ に入ったことで `./...` によるスキャンに files/ 下のgoファイルが引っかからなくなったので不要になった。

* delete wrong dir in "logdata-clean"

    ターゲット名を `_logdata-clean` から `logdata-clean` に直した時に、削除すべきディレクトリ名を誤って修正してしまってた。