### PR TITLE
Skip downloading not uploaded files

### DIFF
--- a/internal/slacklog/message.go
+++ b/internal/slacklog/message.go
@@ -363,6 +363,12 @@ type MessageFile struct {
 	HasRichPreview     bool   `json:"has_rich_preview"`
 }
 
+// IsSlackHosted は、ファイルが slack.com にホストされている場合に true を返します。
+// MessageFile のファイルは slack.com にアップロードされていない場合があります。
+func (f *MessageFile) IsSlackHosted() bool {
+	return strings.HasPrefix(f.URLPrivate, "https://files.slack.com/")
+}
+
 func (f *MessageFile) TopLevelMimetype() string {
 	i := strings.Index(f.Mimetype, "/")
 	if i < 0 {

--- a/subcmd/download_files.go
+++ b/subcmd/download_files.go
@@ -56,7 +56,17 @@ func generateMessageFileTargets(d *slacklog.Downloader, s *slacklog.LogStore, ou
 		}
 
 		for _, msg := range msgs {
+			if !msg.Upload {
+				continue
+			}
 			for _, f := range msg.Files {
+				// 基本的に msg.Upload の判定で弾けるはずだが、
+				// 複数のファイルが含まれていた場合が不明。
+				// 念のためこちらでもチェックして弾くようにしておく
+				if !f.IsSlackHosted() {
+					continue
+				}
+
 				targetDir := filepath.Join(outputDir, f.ID)
 				err := os.MkdirAll(targetDir, 0777)
 				if err != nil {

--- a/templates/channel_per_month_index.tmpl
+++ b/templates/channel_per_month_index.tmpl
@@ -150,6 +150,7 @@
               <div class="mt-2 border p-3">
                 {{- range .Files }}
                 <div>
+                  {{- if .IsSlackHosted }}
                   <a href="{{ $.baseURL }}/files/{{ .OriginalFilePath }}">
                   {{- if eq .TopLevelMimetype "image" }}
                   <img src="{{ $.baseURL }}/files/{{ .ThumbImagePath }}" width="{{ .ThumbImageWidth }}" height="{{ .ThumbImageHeight }}" alt="{{ .Title }}" />
@@ -160,6 +161,10 @@
                   <span class="f5">[[ダウンロード: {{ .Title }}({{ .PrettyType }})]]</span>
                   {{- end }}
                   </a>
+                  {{- else }}
+                  {{- /* TODO: 外部ページへのリンクだということがわかりやすい表示にする */ -}}
+                  <a href="{{ .URLPrivate }}">{{ .Title }}</a>
+                  {{- end }}
                 </div>
                 {{- end }}
               </div>


### PR DESCRIPTION
message に添付されている files の中には、slack.com へアップロードされていない、外部へのリンクが含まれる場合があることが判明しました。

そこで、

1. message.upload フラグが立っていないものはダウンロードしない
   
   このフラグは今のところ、

   - gist.github.com へのリンク (新規で作成する方法が不明…昔だけの仕様の可能性あり)
   - すでにアップロード済みのファイルの2回目以降の投稿

   で確認されています。
   message 側についているフラグなのが気になるところ…複数のファイルの一部だけがアップロードされた場合にどうなるのか不明。

2. ダウンロードしなかったファイルへの html での参照はただのリンクにする

   2回目以降の投稿の件があるため、この判定は message.upload フラグではできません。
   仕方ないのでファイルの元の場所のドメインからふんわり判定することにします。