### PR TITLE
improve site_diff.sh

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
 
     - name: 'Compare site'
       run: |
-        ./scripts/site_diff.sh -d -o tmp/site.diff
+        ./scripts/site_diff.sh -o tmp/site.diff
 
     - uses: actions/upload-artifact@v2
       with:

--- a/scripts/site_diff.sh
+++ b/scripts/site_diff.sh
@@ -51,9 +51,9 @@ generate_site() {
   if [ -d _logdata ] ; then
     filesdir=_logdata/files/
   fi
-  ${cmd} generate-html scripts/config.json ${tmpldir} ${filesdir} ${logdir} ${outdir}/ > ${outdir}.generate-html.log 2>&1
+  ${cmd} generate-html scripts/config.json ${tmpldir} ${filesdir} ${logdir} ${outdir}/ > ${outdir}.generate-html.log 2>&1 || ( cat ${outdir}.generate-html.log && exit 1 )
   rm -f ${cmd}
-  ./scripts/build.sh -o $outdir > ${outdir}.build.log 2>&1
+  ./scripts/build.sh -o $outdir > ${outdir}.build.log 2>&1 || ( cat ${outdir}.build.log && exit 1 )
 }
 
 if [ $clean -ne 0 ] ; then
@@ -101,5 +101,8 @@ if [ x"$outdiff" = x ] ; then
   echo "" 1>&2
   diff -uNr -x sitemap.xml ${base_pages} ${current_pages} || true
 else
-  diff -uNr -x sitemap.xml ${base_pages} ${current_pages} > "$outdiff" || true
+  diff -uNr -x sitemap.xml ${base_pages} ${current_pages} > "$outdiff" || (
+    echo "" 1>&2
+    echo "have some diff, please check $outdiff" 1>&2
+  )
 fi


### PR DESCRIPTION
fix #97

* ci.yml で呼び出すときの `-d` オプションを削除した
* 外部コマンド (generate-html & scripts/build.sh) が失敗したときにそのログを出力するようにした