### PR TITLE
raise an error for uknown properties in JSON

### DIFF
--- a/internal/slacklog/json.go
+++ b/internal/slacklog/json.go
@@ -13,7 +13,9 @@ func ReadFileAsJSON(filename string, dst interface{}) error {
 		return err
 	}
 	defer f.Close()
-	err = json.NewDecoder(f).Decode(dst)
+	d := json.NewDecoder(f)
+	d.DisallowUnknownFields()
+	err = d.Decode(dst)
 	if err != nil {
 		return err
 	}

--- a/internal/slacklog/user.go
+++ b/internal/slacklog/user.go
@@ -82,4 +82,12 @@ type UserProfile struct {
 	StatusTextCanonical   string      `json:"status_text_canonical"`
 	Team                  string      `json:"team"`
 	BotID                 string      `json:"bot_id"`
+
+	// added for https://github.com/vim-jp/slacklog-generator/issues/69
+	// 「unknown な JSON のフィールドがあったらエラーにする」
+	AlwaysActive  bool   `json:"always_active"`
+	ApiAppID      string `json:"api_app_id"`
+	Image1024     string `json:"image_1024"`
+	ImageOriginal string `json:"image_original"`
+	IsCustomImage bool   `json:"is_custom_image"`
 }


### PR DESCRIPTION
fix #69 

将来のフィールドの追加を見逃さないためにチェックをONにした。
結果 users.json に5つの未知のフィールドがあることがわかった。