### PR TITLE
add "serve" sub-command

### DIFF
--- a/subcmd/serve/serve.go
+++ b/subcmd/serve/serve.go
@@ -1,0 +1,50 @@
+package serve
+
+import (
+	"flag"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+func newReverseProxy(targetURL string) (*httputil.ReverseProxy, error) {
+	u, err := url.Parse(targetURL)
+	if err != nil {
+		return nil, err
+	}
+	rp := httputil.NewSingleHostReverseProxy(u)
+	orig := rp.Director
+	rp.Director = func(r *http.Request) {
+		orig(r)
+		r.Host = "" //u.Host
+	}
+	return rp, nil
+}
+
+// Run starts combined HTTP server (file + reverse proxy) to serve slacklog for
+// development.
+func Run(args []string) error {
+	var (
+		addr   string
+		htdocs string
+		target string
+	)
+	fs := flag.NewFlagSet("serve", flag.ExitOnError)
+	fs.StringVar(&addr, "addr", ":8001", "address for serve")
+	fs.StringVar(&htdocs, "htdocs", "_site", "root of files")
+	fs.StringVar(&target, "target", "https://vim-jp.org/slacklog/", "proxy target endpoint")
+	err := fs.Parse(args)
+	if err != nil {
+		return err
+	}
+
+	proxy, err := newReverseProxy(target)
+	if err != nil {
+		return err
+	}
+	http.Handle("/files/", proxy)
+	http.Handle("/emojis/", proxy)
+	http.Handle("/", http.FileServer(http.Dir(htdocs)))
+
+	return http.ListenAndServe(addr, nil)
+}

--- a/subcmd/subcmd.go
+++ b/subcmd/subcmd.go
@@ -3,6 +3,8 @@ package subcmd
 import (
 	"fmt"
 	"os"
+
+	"github.com/vim-jp/slacklog-generator/subcmd/serve"
 )
 
 // Run runs one of sub-commands.
@@ -29,6 +31,8 @@ func Run() error {
 		return DownloadFiles(args)
 	case "generate-html":
 		return GenerateHTML(args)
+	case "serve":
+		return serve.Run(args)
 	}
 
 	return fmt.Errorf("unknown subcmd: %s", subCmdName)


### PR DESCRIPTION
開発用に特殊なファイルサーバを作りました。
以下のコマンドで起動できます。

```console
$ go build
$ ./slacklog-generator serve
```

普通に _site/ 下をサーブするのですが `/files/` と `/emojis/` は
https://vim-jp.org/slacklog/ をリバースプロキシします。
つまり _site/files/ と _site/emojis/ を _logdata からコピーする必要がなくなります。

ポートはデフォでは `:8001` で開いてますが `-addr` オプションで指定もできます。