### PR TITLE
implement 'fetch-channels'

### DIFF
--- a/internal/slackadapter/common.go
+++ b/internal/slackadapter/common.go
@@ -32,11 +32,3 @@ func Timestamp(t *time.Time) string {
 	}
 	return fmt.Sprintf("%d.%6d", t.Unix(), t.Nanosecond()/1000)
 }
-
-// BoolString converts bool to string (true / false).
-func BoolString(b bool) string {
-	if b {
-		return "true"
-	}
-	return "false"
-}

--- a/internal/slackadapter/common.go
+++ b/internal/slackadapter/common.go
@@ -32,3 +32,11 @@ func Timestamp(t *time.Time) string {
 	}
 	return fmt.Sprintf("%d.%6d", t.Unix(), t.Nanosecond()/1000)
 }
+
+// BoolString converts bool to string (true / false).
+func BoolString(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/internal/slackadapter/conversations.go
+++ b/internal/slackadapter/conversations.go
@@ -1,0 +1,55 @@
+package slackadapter
+
+import (
+	"context"
+
+	"github.com/slack-go/slack"
+	"github.com/vim-jp/slacklog-generator/internal/slacklog"
+)
+
+// ConversationsParams is optional parameters for Conversations
+type ConversationsParams struct {
+	Cursor          Cursor   `json:"cursor,omitempty"`
+	Limit           int      `json:"limit,omitempty"`
+	ExcludeArchived string   `json:"excludeArchived,omitempty"`
+	Types           []string `json:"types,omitempty"`
+}
+
+// ConversationsResponse is response for Conversations
+type ConversationsResponse struct {
+	Ok               bool                `json:"ok"`
+	Channels         []*slacklog.Channel `json:"channels,omitempty"`
+	ResponseMetadata *NextCursor         `json:"response_metadata"`
+}
+
+// Conversations gets conversation channels in a channel.
+func Conversations(ctx context.Context, token string, params ConversationsParams) (*ConversationsResponse, error) {
+	client := slack.New(token)
+	channels, nextCursor, err := client.GetConversationsContext(ctx, &slack.GetConversationsParameters{
+		Cursor:          string(params.Cursor),
+		Limit:           params.Limit,
+		ExcludeArchived: params.ExcludeArchived,
+		Types:           params.Types,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var logChannels []*slacklog.Channel
+	for _, c := range channels {
+		logChannels = append(logChannels, &slacklog.Channel{
+			Channel: c,
+		})
+	}
+
+	res := &ConversationsResponse{
+		Ok:       true,
+		Channels: logChannels,
+	}
+	if nextCursor != "" {
+		res.ResponseMetadata = &NextCursor{
+			NextCursor: Cursor(nextCursor),
+		}
+	}
+	return res, nil
+}

--- a/internal/slackadapter/conversations.go
+++ b/internal/slackadapter/conversations.go
@@ -2,6 +2,7 @@ package slackadapter
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/slack-go/slack"
 	"github.com/vim-jp/slacklog-generator/internal/slacklog"
@@ -28,7 +29,7 @@ func Conversations(ctx context.Context, token string, params ConversationsParams
 	channels, nextCursor, err := client.GetConversationsContext(ctx, &slack.GetConversationsParameters{
 		Cursor:          string(params.Cursor),
 		Limit:           params.Limit,
-		ExcludeArchived: BoolString(params.ExcludeArchived),
+		ExcludeArchived: strconv.FormatBool(params.ExcludeArchived),
 		Types:           params.Types,
 	})
 	if err != nil {

--- a/internal/slackadapter/conversations.go
+++ b/internal/slackadapter/conversations.go
@@ -11,7 +11,7 @@ import (
 type ConversationsParams struct {
 	Cursor          Cursor   `json:"cursor,omitempty"`
 	Limit           int      `json:"limit,omitempty"`
-	ExcludeArchived string   `json:"excludeArchived,omitempty"`
+	ExcludeArchived bool     `json:"excludeArchived,omitempty"`
 	Types           []string `json:"types,omitempty"`
 }
 
@@ -28,7 +28,7 @@ func Conversations(ctx context.Context, token string, params ConversationsParams
 	channels, nextCursor, err := client.GetConversationsContext(ctx, &slack.GetConversationsParameters{
 		Cursor:          string(params.Cursor),
 		Limit:           params.Limit,
-		ExcludeArchived: params.ExcludeArchived,
+		ExcludeArchived: BoolString(params.ExcludeArchived),
 		Types:           params.Types,
 	})
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/joho/godotenv"
 	cli "github.com/urfave/cli/v2"
 	"github.com/vim-jp/slacklog-generator/subcmd"
+	"github.com/vim-jp/slacklog-generator/subcmd/fetchchannels"
 	"github.com/vim-jp/slacklog-generator/subcmd/fetchmessages"
 	"github.com/vim-jp/slacklog-generator/subcmd/serve"
 )
@@ -29,6 +30,7 @@ func main() {
 		subcmd.GenerateHTMLCommand,        // "generate-html"
 		serve.Command,                     // "serve"
 		fetchmessages.NewCLICommand(),     // "fetch-messages"
+		fetchchannels.NewCLICommand(),     // "fetch-channels"
 	}
 
 	err = app.Run(os.Args)

--- a/subcmd/fetchchannels/fetchchannels.go
+++ b/subcmd/fetchchannels/fetchchannels.go
@@ -1,0 +1,108 @@
+package fetchchannels
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"os"
+	"path/filepath"
+
+	cli "github.com/urfave/cli/v2"
+	"github.com/vim-jp/slacklog-generator/internal/jsonwriter"
+	"github.com/vim-jp/slacklog-generator/internal/slackadapter"
+)
+
+// Run runs "fetch-channels" sub-command. It fetch channels in the workspace.
+func Run(args []string) error {
+	var (
+		token   string
+		datadir string
+		verbose bool
+	)
+	fs := flag.NewFlagSet("fetch-channels", flag.ExitOnError)
+	fs.StringVar(&token, "token", os.Getenv("SLACK_TOKEN"), `slack token. can be set by SLACK_TOKEN env var`)
+	fs.StringVar(&datadir, "datadir", "_logdata", `directory to load/save data`)
+	fs.BoolVar(&verbose, "verbose", false, "verbose log")
+	err := fs.Parse(args)
+	if err != nil {
+		return err
+	}
+	if token == "" {
+		return errors.New("SLACK_TOKEN environment variable requied")
+	}
+	return run(token, datadir, verbose)
+}
+
+func run(token, datadir string, verbose bool) error {
+	outfile := filepath.Join(datadir, "channels.json")
+	fw, err := jsonwriter.CreateFile(outfile, true)
+	if err != nil {
+		return err
+	}
+	err = slackadapter.IterateCursor(context.Background(),
+		slackadapter.CursorIteratorFunc(func(ctx context.Context, c slackadapter.Cursor) (slackadapter.Cursor, error) {
+			r, err := slackadapter.Conversations(ctx, token, slackadapter.ConversationsParams{
+				Cursor: c,
+				Limit:  100,
+			})
+			if err != nil {
+				return "", err
+			}
+			for _, c := range r.Channels {
+				err := fw.Write(c)
+				if err != nil {
+					return "", err
+				}
+			}
+			if m := r.ResponseMetadata; m != nil {
+				return m.NextCursor, nil
+			}
+			return "", nil
+		}))
+	if err != nil {
+		// ロールバック相当が好ましいが今はまだその時期ではない
+		fw.Close()
+		return err
+	}
+	if err := fw.Close(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewCLICommand creates a cli.Command, which provides "fetch-channels"
+// sub-command.
+func NewCLICommand() *cli.Command {
+	var (
+		token   string
+		datadir string
+		verbose bool
+	)
+	return &cli.Command{
+		Name:  "fetch-channels",
+		Usage: "fetch channels in the workspace",
+		Action: func(c *cli.Context) error {
+			return run(token, datadir, verbose)
+		},
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:        "token",
+				Usage:       "slack token",
+				EnvVars:     []string{"SLACK_TOKEN"},
+				Destination: &token,
+			},
+			&cli.StringFlag{
+				Name:        "datadir",
+				Usage:       "directory to load/save data",
+				Value:       "_logdata",
+				Destination: &datadir,
+			},
+			&cli.BoolFlag{
+				Name:        "verbose",
+				Usage:       "verbose log",
+				Destination: &verbose,
+			},
+		},
+	}
+}


### PR DESCRIPTION
channel一覧を取得する fetch-channels subcommand の実装

一応自分専用のWorkspaceでfetch-channels -> fetch-messagesを呼び出して、
全履歴を確認できたので、動作確認はできています。

## 悩みポイント

- refactor: インターフェイスをConversationsHistoryとどこまで揃えるかちょっと悩む
  - OK fieldいっそ捨てるか: Goのライブラリが隠蔽しているAPIがあった
  - HasMoreもういっそ捨てるか
    - APIによっては帰ってこないし、slackadaptor.XXXResponseに直にCursor生やしてしまっても良さそう

