### PR TITLE
結果が空の場合、nullを出力せずファイルを作らない

### DIFF
--- a/internal/jsonwriter/jsonwriter.go
+++ b/internal/jsonwriter/jsonwriter.go
@@ -26,6 +26,9 @@ func (fw *fileWriter) Write(v interface{}) error {
 }
 
 func (fw *fileWriter) Close() error {
+	if len(fw.buf) == 0 {
+		return nil
+	}
 	// FIXME: ファイルの作成が Close まで遅延している。本来なら CreateFile のタ
 	// イミングでやるのが好ましいが、いましばらく目を瞑る
 	f, err := os.Create(fw.name)


### PR DESCRIPTION
ファイルをつくるものの、中身がないときにnullになってしまっていたので修正。

`[]` を出力することも考えたが、ファイル数が増えるだけで良いことないはずなのでそもそも作らない対応。
