### PR TITLE
Download thumbnail of videos

### DIFF
--- a/internal/slacklog/slack.go
+++ b/internal/slacklog/slack.go
@@ -19,7 +19,7 @@ func HostBySlack(f slack.File) bool {
 func LocalName(f slack.File, url, suffix string) string {
 	ext := filepath.Ext(url)
 	nameExt := filepath.Ext(f.Name)
-	name := f.Name[:len(f.Name)-len(ext)]
+	name := f.Name[:len(f.Name)-len(nameExt)]
 	if ext == "" {
 		ext = nameExt
 		if ext == "" {

--- a/internal/slacklog/slack.go
+++ b/internal/slacklog/slack.go
@@ -92,5 +92,5 @@ func ThumbImageHeight(f slack.File) int {
 
 // ThumbVideoPath returns local path of thumbnail for the video.
 func ThumbVideoPath(f slack.File) string {
-	return path.Join(f.ID, url.PathEscape(LocalName(f, f.ThumbVideo, "_thumb_video")))
+	return path.Join(f.ID, url.PathEscape(LocalName(f, f.ThumbVideo, "_video")))
 }

--- a/subcmd/download_files.go
+++ b/subcmd/download_files.go
@@ -75,6 +75,7 @@ func urlAndSuffixes(f slack.File) map[string]string {
 		f.Thumb960:    "_960",
 		f.Thumb1024:   "_1024",
 		f.Thumb360Gif: "_360",
+		f.ThumbVideo:  "_video",
 	}
 }
 

--- a/subcmd/download_files.go
+++ b/subcmd/download_files.go
@@ -65,17 +65,20 @@ func downloadFiles(c *cli.Context) error {
 
 func urlAndSuffixes(f slack.File) map[string]string {
 	return map[string]string{
-		f.URLPrivate:  "",
-		f.Thumb64:     "_64",
-		f.Thumb80:     "_80",
-		f.Thumb160:    "_160",
-		f.Thumb360:    "_360",
-		f.Thumb480:    "_480",
-		f.Thumb720:    "_720",
-		f.Thumb960:    "_960",
-		f.Thumb1024:   "_1024",
-		f.Thumb360Gif: "_360",
-		f.ThumbVideo:  "_video",
+		f.URLPrivate:   "",
+		f.Thumb64:      "_64",
+		f.Thumb80:      "_80",
+		f.Thumb160:     "_160",
+		f.Thumb360:     "_360",
+		f.Thumb480:     "_480",
+		f.Thumb720:     "_720",
+		f.Thumb800:     "_800",
+		f.Thumb960:     "_960",
+		f.Thumb1024:    "_1024",
+		f.Thumb360Gif:  "_360_gif",
+		f.Thumb480Gif:  "_480_gif",
+		f.DeanimateGif: "_deanimate_gif",
+		f.ThumbVideo:   "_video",
 	}
 }
 


### PR DESCRIPTION
- Fixed a bug: When the file extension of filename and the file extension of URL are different, filename of downloaded file may be wrong.
  - This may occur for videos (filename is `a.mp4` and name of thumbnail file is `a.jpeg`).
- Now, downloads thumbnail of videos.