### PR TITLE
set attachment image width 80

### DIFF
--- a/templates/channel_per_month/attachment.tmpl
+++ b/templates/channel_per_month/attachment.tmpl
@@ -71,7 +71,7 @@
     {{- if .ThumbURL }}
       <div class="d-flex">
         <div class="mt-2">
-          <img src="{{ .ThumbURL }}" width="{{ .ThumbWidth }}" height="{{ .ThumbHeight }}" alt="{{ html .Title }}" />
+          <img src="{{ .ThumbURL }}" width="80" alt="{{ html .Title }}" />
         </div>
       </div>
     {{- end }}


### PR DESCRIPTION
before: 提供されてる画像サイズで表示されている
![image](https://user-images.githubusercontent.com/237271/90880562-9aa7f000-e3e3-11ea-8a50-47a4977b3db4.png)
after: 横幅 80に固定(slack のサイズと一緒)
![image](https://user-images.githubusercontent.com/237271/90880600-ae535680-e3e3-11ea-92fc-d8e30b669b84.png)
