### PR TITLE
Fix the case thread root is deleted

### DIFF
--- a/internal/slacklog/thread.go
+++ b/internal/slacklog/thread.go
@@ -24,7 +24,10 @@ func (th Thread) ReplyCount() int {
 
 // RootText returns text of root message of the thread.
 func (th Thread) RootText() string {
-	return th.rootMsg.Text
+	if th.rootMsg != nil {
+		return th.rootMsg.Text
+	}
+	return ""
 }
 
 // Replies returns replied messages for the thread.


### PR DESCRIPTION
`invalid memory address or nil pointer dereference` occurs when root message is deleted.