### PR TITLE
Move recent log links up

### DIFF
--- a/internal/slacklog/generator.go
+++ b/internal/slacklog/generator.go
@@ -164,11 +164,11 @@ func (g *HTMLGenerator) generateChannelDir(path string, channel Channel) (bool, 
 func (g *HTMLGenerator) generateChannelIndex(channel Channel, keys []MessageMonthKey, path string) error {
 	sort.Slice(keys, func(i, j int) bool {
 		if keys[i].year < keys[j].year {
-			return true
-		} else if keys[i].year > keys[j].year {
 			return false
+		} else if keys[i].year > keys[j].year {
+			return true
 		}
-		return keys[i].month < keys[j].month
+		return keys[i].month > keys[j].month
 	})
 
 	params := make(map[string]interface{})


### PR DESCRIPTION
昔の発言から探すよりも最近の発言を他で紹介したいと思うことの方が多いので、新しい方を上に変更。