### PR TITLE
Make <pre> scrollable

### DIFF
--- a/static/assets/css/site.css
+++ b/static/assets/css/site.css
@@ -46,6 +46,7 @@ pre {
   color: white;
   background-color: black;
   padding: 0.5em;
+  overflow: scroll;
 }
 
 .slacklog-emoji {


### PR DESCRIPTION
現状コード貼り付け部分はoverflow-hidden classのみ設定されているため、狭い画面の場合コードが見切れてしまっていた
preタグにoverflow: scrollを設定して見切れた際でもスクロール可能にした